### PR TITLE
APIS-964: Revert email sender back to 'HMRC API Developer Hub'

### DIFF
--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplates.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.hmrcemailrenderer.templates.FromAddress
   * Templates used by the API Platform.
   */
 object ApiTemplates {
-  val from = FromAddress.noReply("HMRC API Developer")
+  val from = FromAddress.noReply("HMRC API Developer Hub")
 
   val templates = Seq(
     MessageTemplate.create(


### PR DESCRIPTION
We have a failing acceptance test that explicitly checks for the sender being 'HMRC API Developer Hub'. Looking at the commit history (https://github.com/hmrc/hmrc-email-renderer/commit/96dbc2bfd845736cac9f6f99d188651d0c55d56c) it was changed from **HMRC API Developer Hub** to **HMRC API Developer** as part of a refactor – it looks like it a typo rather than intentional though.

This PR reverts that edit.