### PR TITLE
Revert "Apis-878 - Edit content of verification email"

### DIFF
--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/verificationEmail.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/verificationEmail.scala.html
@@ -1,6 +1,7 @@
 @(params: Map[String, Any])
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Activate your account") {
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.salutation(params)
 <p style="margin: 0 0 30px; font-size: 19px;">Click on the link below to verify your email address:</p>
 <p style="margin: 0 0 30px; font-size: 19px;"><a href="@{params("verificationLink")}" style="color: #005EA5;">@{params("verificationLink")}</a></p>
-<p style="margin: 0 0 30px; font-size: 19px;">From HMRC @{params.getOrElse("developerHubTitle", "Developer Hub")}</p>
+<p style="margin: 0 0 30px; font-size: 19px;">From HMRC Digital @{params.getOrElse("developerHubTitle", "Developer Hub")}</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/verificationEmail.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/verificationEmail.scala.txt
@@ -1,9 +1,11 @@
 @(params: Map[String, Any])Activate your account
 
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.salutation(params)
+
 Click on the link below to verify your email address:
 
 @{params("verificationLink")}
 
-From HMRC @{params.getOrElse("developerHubTitle", "Developer Hub")}
+From HMRC Digital @{params.getOrElse("developerHubTitle", "Developer Hub")}
 
 @{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer()}

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiVerficationEmailSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiVerficationEmailSpec.scala
@@ -43,12 +43,12 @@ class ApiVerficationEmailSpec extends UnitSpec with Matchers {
       renderedHtml.body should include("<p style=\"margin: 0 0 30px; font-size: 19px;\">Click on the link below to verify your email address:</p>")
       renderedHtml.body should include("<p style=\"margin: 0 0 30px; font-size: 19px;\"><a href=\"" + verificationLink +
         "\" style=\"color: #005EA5;\">" + verificationLink + "</a></p>")
-      renderedHtml.body should include("<p style=\"margin: 0 0 30px; font-size: 19px;\">From HMRC Developer Hub</p>")
+      renderedHtml.body should include("<p style=\"margin: 0 0 30px; font-size: 19px;\">From HMRC Digital Developer Hub</p>")
     }
     "render with developerHubTitle" in new TestCase {
       val templateParamsPlus = templateParams + ("developerHubTitle" -> developerHubTitle)
       val renderedHtml = api.html.verificationEmail.render(templateParamsPlus)
-      renderedHtml.body should include("<p style=\"margin: 0 0 30px; font-size: 19px;\">From HMRC " + developerHubTitle + "</p>")
+      renderedHtml.body should include("<p style=\"margin: 0 0 30px; font-size: 19px;\">From HMRC Digital " + developerHubTitle + "</p>")
     }
   }
 
@@ -59,12 +59,12 @@ class ApiVerficationEmailSpec extends UnitSpec with Matchers {
       renderedTxt.body should include("Dear Mr Smith")
       renderedTxt.body should include("Click on the link below to verify your email address:")
       renderedTxt.body should include(verificationLink)
-      renderedTxt.body should include("From HMRC Developer Hub")
+      renderedTxt.body should include("From HMRC Digital Developer Hub")
     }
     "render with developerHubTitle" in new TestCase {
       val templateParamsPlus = templateParams + ("developerHubTitle" -> developerHubTitle)
       val renderedTxt = api.txt.verificationEmail.render(templateParamsPlus)
-      renderedTxt.body should include("From HMRC " + developerHubTitle)
+      renderedTxt.body should include("From HMRC Digital " + developerHubTitle)
     }
   }
 }


### PR DESCRIPTION
Reverts hmrc/hmrc-email-renderer#82

Reverting because this broke a test and will block merging other upcoming changes.  Will re-merge when it is fixed.