### PR TITLE
Add new email teplate for VOA - RALD

### DIFF
--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -486,12 +486,8 @@ object TemplateParams {
     ),
     "rald_not_connected" -> Map(
       "referenceNumber" -> "9999000666",
-      "fullName" -> "Jimmy McJimmney",
       "email" -> "jimm@jimmjimm.com",
-      "phoneNumber" -> "01234567890",
-      "address" -> "1 Jim Street, Jimtown, Jimregion",
-      "postcode" -> "BN12 4AX",
-      "additionalInformation" -> "I have left the property 6 months ago. The new occupier is Tim McTimmney"
+      "phoneNumber" -> "01234567890"
     ),
     "bars_alert" -> Map(
       "baRefNumber" -> "BA : ba5090",

--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -484,6 +484,15 @@ object TemplateParams {
       "postcode" -> "Postcode: BN12 4AX",
       "expiryDate" -> "We will delete any unsubmitted information on 28 July 2016"
     ),
+    "rald_not_connected" -> Map(
+      "referenceNumber" -> "9999000666",
+      "fullName" -> "Jimmy McJimmney",
+      "email" -> "jimm@jimmjimm.com",
+      "phoneNumber" -> "01234567890",
+      "address" -> "1 Jim Street, Jimtown, Jimregion",
+      "postcode" -> "BN12 4AX",
+      "additionalInformation" -> "I have left the property 6 months ago. The new occupier is Tim McTimmney"
+    ),
     "bars_alert" -> Map(
       "baRefNumber" -> "BA : ba5090",
       "fileName" -> "File name : Barnet_CT.xml",

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/rald/RaldTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/rald/RaldTemplates.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.hmrcemailrenderer.templates.rald
 
-import uk.gov.hmrc.hmrcemailrenderer.domain.MessageTemplate
+import uk.gov.hmrc.hmrcemailrenderer.domain.{MessagePriority, MessageTemplate}
 import uk.gov.hmrc.hmrcemailrenderer.templates.FromAddress
 import uk.gov.hmrc.hmrcemailrenderer.templates.ServiceIdentifier.RentalAndLeaseDetails
 
@@ -28,6 +28,17 @@ object RaldTemplates {
       service = RentalAndLeaseDetails,
       subject = "Your saved Rent and Lease details expires in 90 days.",
       plainTemplate = txt.rald.f,
-      htmlTemplate = html.rald.f)
+      htmlTemplate = html.rald.f),
+
+    MessageTemplate.create(
+      templateId = "rald_not_connected",
+      fromAddress = FromAddress.noReply("Rent and Lease Details"),
+      service = RentalAndLeaseDetails,
+      subject = "RALD - Not connected to",
+      plainTemplate = txt.raldNotConnected.f,
+      htmlTemplate = html.raldNotConnected.f,
+      priority = Some(MessagePriority.Standard)
+    )
+
   )
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/rald/raldNotConnected.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/rald/raldNotConnected.scala.html
@@ -23,7 +23,6 @@
 
     <p><b>Reference number:</b> @params("referenceNumber")</p>
 
-    <p><b>Name:</b> @params("fullName")<br />
     @params.get("email").map { email =>
         <b>Email address:</b> @email <br />
     }.getOrElse("")
@@ -32,11 +31,6 @@
     <b>Phone number:</b> @phoneNumber <br />
     }.getOrElse("")
     </p>
-
-    <p><b>Address:</b> @params("address")<br />
-    <b>Postcode:</b> @params("postcode")</p>
-
-    <p><b>Additional information:</b><br /> @params("additionalInformation")</p>
 
     <p>From Valuation Office Agency - Rent and lease details service </p>
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/rald/raldNotConnected.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/rald/raldNotConnected.scala.html
@@ -1,0 +1,44 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(params: Map[String, Any])
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, ""){
+
+<h1>Rent and lease details - Not connected property</h1>
+
+<div style="margin: 0 0 30px; font-size: 19px;">
+
+    <p><b>Reference number:</b> @params("referenceNumber")</p>
+
+    <p><b>Name:</b> @params("fullName")<br />
+    @params.get("email").map { email =>
+        <b>Email address:</b> @email <br />
+    }.getOrElse("")
+
+    @params.get("phoneNumber").map { phoneNumber =>
+    <b>Phone number:</b> @phoneNumber <br />
+    }.getOrElse("")
+    </p>
+
+    <p><b>Address:</b> @params("address")<br />
+    <b>Postcode:</b> @params("postcode")</p>
+
+    <p><b>Additional information:</b><br /> @params("additionalInformation")</p>
+
+    <p>From Valuation Office Agency - Rent and lease details service </p>
+
+</div>
+}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/rald/raldNotConnected.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/rald/raldNotConnected.scala.txt
@@ -1,0 +1,18 @@
+@(params: Map[String, Any])
+Rent and lease details - Not connected property
+
+Reference number: @params("referenceNumber")
+
+Name:@params("fullName")
+@params.get("email").map { email =>Email address: @email}.getOrElse("")
+@params.get("phoneNumber").map { phoneNumber =>Phone number: @phoneNumber}.getOrElse("")
+
+Address: @params("address")
+Postcode: @params("postcode")
+
+Additional information:
+@params("additionalInformation")
+
+From Valuation Office Agency - Rent and lease details service
+
+@{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer()}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/rald/raldNotConnected.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/rald/raldNotConnected.scala.txt
@@ -3,15 +3,8 @@ Rent and lease details - Not connected property
 
 Reference number: @params("referenceNumber")
 
-Name:@params("fullName")
 @params.get("email").map { email =>Email address: @email}.getOrElse("")
 @params.get("phoneNumber").map { phoneNumber =>Phone number: @phoneNumber}.getOrElse("")
-
-Address: @params("address")
-Postcode: @params("postcode")
-
-Additional information:
-@params("additionalInformation")
 
 From Valuation Office Agency - Rent and lease details service
 

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
@@ -262,6 +262,7 @@ class TemplateLocatorSpec extends UnitSpec with OneAppPerSuite {
         "gmp_bulk_upload_received",
         "gmp_bulk_upload_processed",
         "rald_alert",
+        "rald_not_connected",
         "bars_alert",
         "tcs_renewal_confirmation",
         "register_your_company_verification_email",


### PR DESCRIPTION
New teplate for email which is send to VOA employee when
user submit form with information that he is not connected with property.
This email is ONLY for VOA employees.