### PR TITLE
API-3882: Notification that unused application is to be deleted

### DIFF
--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -160,11 +160,11 @@ object TemplateParams {
       "applicationName"    -> "Tax Software"
     ),
     "apiApplicationToBeDeletedNotification" -> Map(
-      "userFirstName" -> "Fred",
-      "userLastName" -> "Bloggs",
-      "applicationName" -> "Test Application",
-      "environmentName" -> "Sandbox",
-      "timeSinceLastUse" -> "11 months",
+      "userFirstName"           -> "Fred",
+      "userLastName"            -> "Bloggs",
+      "applicationName"         -> "Test Application",
+      "environmentName"         -> "Sandbox",
+      "timeSinceLastUse"        -> "11 months",
       "dateOfScheduledDeletion" -> "1 April 2025"
     ),
     "changeOfEmailAddressNewAddress" -> Map(

--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -159,6 +159,13 @@ object TemplateParams {
       "environmentName"    -> "sandbox",
       "applicationName"    -> "Tax Software"
     ),
+    "apiApplicationToBeDeletedNotification" -> Map(
+      "applicationName" -> "Test Application",
+      "environmentName" -> "External Test",
+      "numberOfMonthsSinceLastUse" -> "11",
+      "numberOfMonthsBeforeDeletion" -> "12",
+      "dateOfScheduledDeletion" -> "1 April 2025"
+    ),
     "changeOfEmailAddressNewAddress" -> Map(
       "verificationLink" -> exampleLinkWithRandomId
     ),

--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -162,8 +162,8 @@ object TemplateParams {
     "apiApplicationToBeDeletedNotification" -> Map(
       "applicationName" -> "Test Application",
       "environmentName" -> "External Test",
-      "numberOfMonthsSinceLastUse" -> "11",
-      "numberOfMonthsBeforeDeletion" -> "12",
+      "timeSinceLastUse" -> "11 months",
+      "timeBeforeDeletion" -> "365 days",
       "dateOfScheduledDeletion" -> "1 April 2025"
     ),
     "changeOfEmailAddressNewAddress" -> Map(

--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -160,6 +160,8 @@ object TemplateParams {
       "applicationName"    -> "Tax Software"
     ),
     "apiApplicationToBeDeletedNotification" -> Map(
+      "userFirstName" -> "Fred",
+      "userLastName" -> "Bloggs",
       "applicationName" -> "Test Application",
       "environmentName" -> "External Test",
       "timeSinceLastUse" -> "11 months",

--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -163,9 +163,8 @@ object TemplateParams {
       "userFirstName" -> "Fred",
       "userLastName" -> "Bloggs",
       "applicationName" -> "Test Application",
-      "environmentName" -> "External Test",
+      "environmentName" -> "Sandbox",
       "timeSinceLastUse" -> "11 months",
-      "timeBeforeDeletion" -> "365 days",
       "dateOfScheduledDeletion" -> "1 April 2025"
     ),
     "changeOfEmailAddressNewAddress" -> Map(

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplates.scala
@@ -191,6 +191,15 @@ object ApiTemplates {
       plainTemplate = txt.apiRemovedClientSecretNotification.f,
       htmlTemplate = html.apiRemovedClientSecretNotification.f,
       priority = Some(MessagePriority.Urgent)
+    ),
+    MessageTemplate.createWithDynamicFromAddress(
+      templateId = "apiApplicationToBeDeletedNotification",
+      fromAddress = extractFromAddress,
+      service = ApiDeveloperHub,
+      subject = "Your application is scheduled to be deleted",
+      plainTemplate = txt.apiApplicationToBeDeletedNotification.f,
+      htmlTemplate = html.apiApplicationToBeDeletedNotification.f,
+      priority = Some(MessagePriority.Standard)
     )
   )
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplates.scala
@@ -196,7 +196,7 @@ object ApiTemplates {
       templateId = "apiApplicationToBeDeletedNotification",
       fromAddress = extractFromAddress,
       service = ApiDeveloperHub,
-      subject = "We will delete your application soon",
+      subject = "We’re deleting your application",
       plainTemplate = txt.apiApplicationToBeDeletedNotification.f,
       htmlTemplate = html.apiApplicationToBeDeletedNotification.f,
       priority = Some(MessagePriority.Standard)

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplates.scala
@@ -196,7 +196,7 @@ object ApiTemplates {
       templateId = "apiApplicationToBeDeletedNotification",
       fromAddress = extractFromAddress,
       service = ApiDeveloperHub,
-      subject = "Your application is scheduled to be deleted",
+      subject = "We will delete your application soon",
       plainTemplate = txt.apiApplicationToBeDeletedNotification.f,
       htmlTemplate = html.apiApplicationToBeDeletedNotification.f,
       priority = Some(MessagePriority.Standard)

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.html
@@ -21,9 +21,14 @@
  <p style="margin: 0 0 30px; font-size: 19px;">We permanently delete applications that have not been used for <strong>@{params("timeBeforeDeletion")}</strong>. They cannot be restored.</p>
  <p style="margin: 0 0 30px; font-size: 19px;">Your application will be deleted on or after <strong>@{params("dateOfScheduledDeletion")}</strong>.</p>
  <h2>What you can do now</h2>
+ <p style="margin: 0 0 30px; font-size: 19px;">If you want to keep this application you need to:</p>
  <ul style="margin: 0 0 30px; font-size: 19px;">
-  <li>If you <strong>want to keep this application</strong> you should make an API call using its credentials prior to the scheduled deletion date.</li>
-  <li>If you <strong>do not want to keep this application</strong> you can sign in to Developer Hub and delete it manually, or allow it to be removed automatically on the scheduled deletion date.</li>
+  <li>make an API call using its credentials before the scheduled deletion date</li>
+ </ul>
+ <p style="margin: 0 0 30px; font-size: 19px;">If you do not want to keep this application you can either:</p>
+ <ul style="margin: 0 0 30px; font-size: 19px;">
+  <li>sign in to Developer Hub and delete it manually</li>
+  <li>allow it to be removed automatically on the scheduled deletion date</li>
  </ul>
  <p style="margin: 0 0 30px; font-size: 19px;">From HMRC Developer Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.html
@@ -15,12 +15,15 @@
  *@
 
 @(params: Map[String, Any])
-@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Your application is scheduled to be deleted") {
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Take action to stop your application being deleted") {
+ <p style="margin: 0 0 30px; font-size: 19px;">Dear @{params("userFirstName")} @{params("userLastName")}</p>
  <p style="margin: 0 0 30px; font-size: 19px;">According to our records, your application <strong>@{params("applicationName")}</strong> in our <strong>@{params("environmentName")}</strong> environment has not been used for <strong>@{params("timeSinceLastUse")}</strong>.</p>
- <p style="margin: 0 0 30px; font-size: 19px;">Applications that have not been used for <strong>@{params("timeBeforeDeletion")}</strong> will be deleted from the Developer Hub and will no longer be available for use.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">We permanently delete applications that have not been used for <strong>@{params("timeBeforeDeletion")}</strong>. They cannot be restored.</p>
  <p style="margin: 0 0 30px; font-size: 19px;">Your application will be deleted on or after <strong>@{params("dateOfScheduledDeletion")}</strong>.</p>
- <p style="margin: 0 0 30px; font-size: 19px;">If you wish to retain this application you should make an API call using its credentials prior to the scheduled deletion date.</p>
- <p style="margin: 0 0 30px; font-size: 19px;">If you do not wish to retain this application you can log in to Developer Hub and delete it manually, or allow it to be deleted automatically on the scheduled deletion date.</p>
- <p style="margin: 0 0 30px; font-size: 19px;">Once deleted the application cannot be restored.</p>
-<p style="margin: 0 0 30px; font-size: 19px;">From HMRC Developer Hub</p>
+ <h2>What you can do now</h2>
+ <ul style="margin: 0 0 30px; font-size: 19px;">
+  <li>If you <strong>want to keep this application</strong> you should make an API call using its credentials prior to the scheduled deletion date.</li>
+  <li>If you <strong>do not want to keep this application</strong> you can sign in to Developer Hub and delete it manually, or allow it to be removed automatically on the scheduled deletion date.</li>
+ </ul>
+ <p style="margin: 0 0 30px; font-size: 19px;">From HMRC Developer Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.html
@@ -20,7 +20,7 @@
  <p style="margin: 0 0 30px; font-size: 19px;">Your <strong>@{params("environmentName")}</strong> application <strong>@{params("applicationName")}</strong> has been inactive for more than <strong>@{params("timeSinceLastUse")}</strong> and will be deleted on <strong>@{params("dateOfScheduledDeletion")}</strong>.</p>
  <p style="margin: 0 0 30px; font-size: 19px;">To keep this application, use it to make an API call before the deletion date.</p>
  <p style="margin: 0 0 30px; font-size: 19px;">If you do nothing, we will automatically delete this application.</p>
- <p style="margin: 0 0 30px; font-size: 19px;">You can manage your email preferences on the Developer Hub at <a href="https://developer.service.hmrc.gov.uk">https://developer.service.hmrc.gov.uk</a></p>
+ <p style="margin: 0 0 30px; font-size: 19px;">You can now manage the types of emails you receive from us in your Developer Hub account under email preferences.</p>
  <p style="margin: 0 0 30px; font-size: 19px;">Do not reply to this email, this inbox is not monitored.</p>
  <p style="margin: 0 0 30px; font-size: 19px;">From HMRC Developer Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.html
@@ -1,0 +1,26 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(params: Map[String, Any])
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Your application is scheduled to be deleted") {
+ <p style="margin: 0 0 30px; font-size: 19px;">According to our records, your application <strong>@{params("applicationName")}</strong> has not been used in our <strong>@{params("environmentName")}</strong> environment for <strong>@{params("numberOfMonthsSinceLastUse")} months</strong>.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">Our policy is that applications remaining unused for <strong>@{params("numberOfMonthsBeforeDeletion")} months</strong> will be deleted from Developer Hub and no longer available for use.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">Your application has been scheduled to be deleted on or after <strong>@{params("dateOfScheduledDeletion")}</strong>.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">If you wish to retain this application you should make an API call using its credentials prior to the scheduled deletion date.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">If you do not wish to retain this application you can log in to Developer Hub and delete it manually, or allow it to be deleted automatically on the scheduled deletion date.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">Once deleted the application cannot be restored.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">From HMRC Developer Hub</p>
+}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.html
@@ -16,9 +16,9 @@
 
 @(params: Map[String, Any])
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Your application is scheduled to be deleted") {
- <p style="margin: 0 0 30px; font-size: 19px;">According to our records, your application <strong>@{params("applicationName")}</strong> has not been used in our <strong>@{params("environmentName")}</strong> environment for <strong>@{params("numberOfMonthsSinceLastUse")} months</strong>.</p>
- <p style="margin: 0 0 30px; font-size: 19px;">Our policy is that applications remaining unused for <strong>@{params("numberOfMonthsBeforeDeletion")} months</strong> will be deleted from Developer Hub and no longer available for use.</p>
- <p style="margin: 0 0 30px; font-size: 19px;">Your application has been scheduled to be deleted on or after <strong>@{params("dateOfScheduledDeletion")}</strong>.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">According to our records, your application <strong>@{params("applicationName")}</strong> in our <strong>@{params("environmentName")}</strong> environment has not been used for <strong>@{params("timeSinceLastUse")}</strong>.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">Applications that have not been used for <strong>@{params("timeBeforeDeletion")}</strong> will be deleted from the Developer Hub and will no longer be available for use.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">Your application will be deleted on or after <strong>@{params("dateOfScheduledDeletion")}</strong>.</p>
  <p style="margin: 0 0 30px; font-size: 19px;">If you wish to retain this application you should make an API call using its credentials prior to the scheduled deletion date.</p>
  <p style="margin: 0 0 30px; font-size: 19px;">If you do not wish to retain this application you can log in to Developer Hub and delete it manually, or allow it to be deleted automatically on the scheduled deletion date.</p>
  <p style="margin: 0 0 30px; font-size: 19px;">Once deleted the application cannot be restored.</p>

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.html
@@ -15,20 +15,12 @@
  *@
 
 @(params: Map[String, Any])
-@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Take action to stop your application being deleted") {
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "We’re deleting your application") {
  <p style="margin: 0 0 30px; font-size: 19px;">Dear @{params("userFirstName")} @{params("userLastName")}</p>
- <p style="margin: 0 0 30px; font-size: 19px;">According to our records, your application <strong>@{params("applicationName")}</strong> in our <strong>@{params("environmentName")}</strong> environment has not been used for <strong>@{params("timeSinceLastUse")}</strong>.</p>
- <p style="margin: 0 0 30px; font-size: 19px;">We permanently delete applications that have not been used for <strong>@{params("timeBeforeDeletion")}</strong>. They cannot be restored.</p>
- <p style="margin: 0 0 30px; font-size: 19px;">Your application will be deleted on or after <strong>@{params("dateOfScheduledDeletion")}</strong>.</p>
- <h2>What you can do now</h2>
- <p style="margin: 0 0 30px; font-size: 19px;">If you want to keep this application you need to:</p>
- <ul style="margin: 0 0 30px; font-size: 19px;">
-  <li>make an API call using its credentials before the scheduled deletion date</li>
- </ul>
- <p style="margin: 0 0 30px; font-size: 19px;">If you do not want to keep this application you can either:</p>
- <ul style="margin: 0 0 30px; font-size: 19px;">
-  <li>sign in to Developer Hub and delete it manually</li>
-  <li>allow it to be removed automatically on the scheduled deletion date</li>
- </ul>
+ <p style="margin: 0 0 30px; font-size: 19px;">Your <strong>@{params("environmentName")}</strong> application <strong>@{params("applicationName")}</strong> has been inactive for more than <strong>@{params("timeSinceLastUse")}</strong> and will be deleted on <strong>@{params("dateOfScheduledDeletion")}</strong>.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">To keep this application, use it to make an API call before the deletion date.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">If you do nothing, we will automatically delete this application.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">You can manage your email preferences on the Developer Hub at <a href="https://developer.service.hmrc.gov.uk">https://developer.service.hmrc.gov.uk</a></p>
+ <p style="margin: 0 0 30px; font-size: 19px;">Do not reply to this email, this inbox is not monitored.</p>
  <p style="margin: 0 0 30px; font-size: 19px;">From HMRC Developer Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.txt
@@ -10,9 +10,12 @@ Your application will be deleted on or after @{params("dateOfScheduledDeletion")
 
 What you can do now
 
-If you want to keep this application you should make an API call using its credentials prior to the scheduled deletion date.
+If you want to keep this application you need to:
+- make an API call using its credentials before the scheduled deletion date
 
-If you do not want to keep this application you can sign in to Developer Hub and delete it manually, or allow it to be deleted automatically on the scheduled deletion date.
+If you do not want to keep this application you can either:
+- sign in to Developer Hub and delete it manually
+- allow it to be removed automatically on the scheduled deletion date
 
 From HMRC Developer Hub
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.txt
@@ -8,7 +8,7 @@ To keep this application, use it to make an API call before the deletion date.
 
 If you do nothing, we will automatically delete this application.
 
-You can manage your email preferences on the Developer Hub at https://developer.service.hmrc.gov.uk
+You can now manage the types of emails you receive from us in your Developer Hub account under email preferences.
 
 Do not reply to this email, this inbox is not monitored.
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.txt
@@ -1,16 +1,18 @@
-@(params: Map[String, Any])Your application is scheduled to be deleted
+@(params: Map[String, Any])Take action to stop your application being deleted
+
+Dear @{params("userFirstName")} @{params("userLastName")}
 
 According to our records, your application @{params("applicationName")} in our @{params("environmentName")} environment has not been used for @{params("timeSinceLastUse")}.
 
-Applications that have not been used for @{params("timeBeforeDeletion")} will be deleted from the Developer Hub and will no longer be available for use.
+We permanently delete applications that have not been used for @{params("timeBeforeDeletion")}. They cannot be restored.
 
 Your application will be deleted on or after @{params("dateOfScheduledDeletion")}.
 
-If you wish to retain this application you should make an API call using its credentials prior to the scheduled deletion date.
+What you can do now
 
-If you do not wish to retain this application you can log in to Developer Hub and delete it manually, or allow it to be deleted automatically on the scheduled deletion date.
+If you want to keep this application you should make an API call using its credentials prior to the scheduled deletion date.
 
-Once deleted the application cannot be restored.
+If you do not want to keep this application you can sign in to Developer Hub and delete it manually, or allow it to be deleted automatically on the scheduled deletion date.
 
 From HMRC Developer Hub
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.txt
@@ -1,0 +1,17 @@
+@(params: Map[String, Any])Your application is scheduled to be deleted
+
+According to our records, your application @{params("applicationName")} has not been used in our @{params("environmentName")} environment for @{params("numberOfMonthsSinceLastUse")} months.
+
+Our policy is that applications remaining unused for @{params("numberOfMonthsBeforeDeletion")} months will be deleted from Developer Hub and no longer available for use.
+
+Your application has been scheduled to be deleted on or after @{params("dateOfScheduledDeletion")}.
+
+If you wish to retain this application you should make an API call using its credentials prior to the scheduled deletion date.
+
+If you do not wish to retain this application you can log in to Developer Hub and delete it manually, or allow it to be deleted automatically on the scheduled deletion date.
+
+Once deleted the application cannot be restored.
+
+From HMRC Developer Hub
+
+@{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer()}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.txt
@@ -1,21 +1,16 @@
-@(params: Map[String, Any])Take action to stop your application being deleted
+@(params: Map[String, Any])We’re deleting your application
 
 Dear @{params("userFirstName")} @{params("userLastName")}
 
-According to our records, your application @{params("applicationName")} in our @{params("environmentName")} environment has not been used for @{params("timeSinceLastUse")}.
+Your @{params("environmentName")} application @{params("applicationName")} has been inactive for more than @{params("timeSinceLastUse")} and will be deleted on @{params("dateOfScheduledDeletion")}.
 
-We permanently delete applications that have not been used for @{params("timeBeforeDeletion")}. They cannot be restored.
+To keep this application, use it to make an API call before the deletion date.
 
-Your application will be deleted on or after @{params("dateOfScheduledDeletion")}.
+If you do nothing, we will automatically delete this application.
 
-What you can do now
+You can manage your email preferences on the Developer Hub at https://developer.service.hmrc.gov.uk
 
-If you want to keep this application you need to:
-- make an API call using its credentials before the scheduled deletion date
-
-If you do not want to keep this application you can either:
-- sign in to Developer Hub and delete it manually
-- allow it to be removed automatically on the scheduled deletion date
+Do not reply to this email, this inbox is not monitored.
 
 From HMRC Developer Hub
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiApplicationToBeDeletedNotification.scala.txt
@@ -1,10 +1,10 @@
 @(params: Map[String, Any])Your application is scheduled to be deleted
 
-According to our records, your application @{params("applicationName")} has not been used in our @{params("environmentName")} environment for @{params("numberOfMonthsSinceLastUse")} months.
+According to our records, your application @{params("applicationName")} in our @{params("environmentName")} environment has not been used for @{params("timeSinceLastUse")}.
 
-Our policy is that applications remaining unused for @{params("numberOfMonthsBeforeDeletion")} months will be deleted from Developer Hub and no longer available for use.
+Applications that have not been used for @{params("timeBeforeDeletion")} will be deleted from the Developer Hub and will no longer be available for use.
 
-Your application has been scheduled to be deleted on or after @{params("dateOfScheduledDeletion")}.
+Your application will be deleted on or after @{params("dateOfScheduledDeletion")}.
 
 If you wish to retain this application you should make an API call using its credentials prior to the scheduled deletion date.
 

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
@@ -141,6 +141,7 @@ class TemplateLocatorSpec extends UnitSpec with OneAppPerSuite {
         "apiStatusChangedNotification",
         "apiAddedClientSecretNotification",
         "apiRemovedClientSecretNotification",
+        "apiApplicationToBeDeletedNotification",
         "changeOfEmailAddress",
         "changeOfEmailAddress_cy",
         "verifyEmailAddress",

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplatesSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplatesSpec.scala
@@ -94,7 +94,7 @@ class ApiTemplatesSpec extends UnitSpec with OneAppPerSuite {
 
       validateTemplate(
         templateId = "apiApplicationToBeDeletedNotification",
-        expectedSubject = "Your application is scheduled to be deleted",
+        expectedSubject = "We will delete your application soon",
         expectedPriority = MessagePriority.Standard)
     }
   }

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplatesSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplatesSpec.scala
@@ -91,6 +91,11 @@ class ApiTemplatesSpec extends UnitSpec with OneAppPerSuite {
         templateId = "apiRemovedClientSecretNotification",
         expectedSubject = "Client Secret Removed",
         expectedPriority = MessagePriority.Urgent)
+
+      validateTemplate(
+        templateId = "apiApplicationToBeDeletedNotification",
+        expectedSubject = "Your application is scheduled to be deleted",
+        expectedPriority = MessagePriority.Standard)
     }
   }
 

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplatesSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplatesSpec.scala
@@ -94,7 +94,7 @@ class ApiTemplatesSpec extends UnitSpec with OneAppPerSuite {
 
       validateTemplate(
         templateId = "apiApplicationToBeDeletedNotification",
-        expectedSubject = "We will delete your application soon",
+        expectedSubject = "We’re deleting your application",
         expectedPriority = MessagePriority.Standard)
     }
   }


### PR DESCRIPTION
Email sent on behalf of the HMRC Developer Hub notifying application owners that their application will be automatically deleted as it has not been used in an extended amount of time.