### PR TITLE
Added two registration emails for Digital Services Tax, one for when …

### DIFF
--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -1625,6 +1625,17 @@ object TemplateParams {
     "cgtpd_private_beta_access" -> Map(
       "name" -> "Jamie Wilson",
       "verificationLink" -> exampleLinkWithRandomId
+    ),
+    "dst_registration_accepted" -> Map(
+        "dstNumber" -> "XADST0000010000",
+        "companyName" -> "Some company Ltd.",
+        "groupCompanyName" -> "Some group company Ltd.",
+        "paymentDeadline" -> "20210401",
+        "submitReturnDeadline" -> "20210731"
+        ),
+    "dst_registration_received" -> Map(
+        "companyName" -> "Some company Ltd.",
+        "groupCompanyName" -> "Some group company Ltd."
     )
   )
 }

--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -1628,13 +1628,13 @@ object TemplateParams {
     ),
     "dst_registration_accepted" -> Map(
         "dstNumber" -> "XADST0000010000",
-        "companyName" -> "Some company Ltd.",
+        "name" -> "Joe Bloggs",
         "groupCompanyName" -> "Some group company Ltd.",
         "paymentDeadline" -> "20210401",
         "submitReturnDeadline" -> "20210731"
         ),
     "dst_registration_received" -> Map(
-        "companyName" -> "Some company Ltd.",
+        "name" -> "Joe Bloggs",
         "groupCompanyName" -> "Some group company Ltd."
     )
   )

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/ServiceIdentifier.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/ServiceIdentifier.scala
@@ -99,4 +99,5 @@ object ServiceIdentifier {
   case object CustomsFinancials extends ServiceIdentifier { override val name = "customsFinancials"}
   case object Cgtpd extends ServiceIdentifier { override val name = "cgtpd"}
   case object Tdq extends ServiceIdentifier { override val name = "tdq"}
+  case object DigitalServicesTax extends ServiceIdentifier { override val name = "dst"}
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocator.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocator.scala
@@ -64,6 +64,7 @@ import uk.gov.hmrc.hmrcemailrenderer.templates.customsfinancials.CustomsFinancia
 import uk.gov.hmrc.hmrcemailrenderer.templates.cgtpd.CgtpdTemplates
 import uk.gov.hmrc.hmrcemailrenderer.templates.tdq.TdqTemplates
 import uk.gov.hmrc.hmrcemailrenderer.templates.htsreminder.HtsReminderTemplates
+import uk.gov.hmrc.hmrcemailrenderer.templates.dst.DstTemplates
 
 trait TemplateLocator {
   def templateGroups: Map[String, Seq[MessageTemplate]] =
@@ -75,6 +76,7 @@ trait TemplateLocator {
         "BARS"                       -> BarsTemplates.templates,
         "Childcare"                  -> ChildcareTemplates.templates,
         "Digital Tariffs"            -> DigitalTariffTemplates.templates,
+        "DST"                        -> DstTemplates.templates,
         "DFS"                        -> DfsTemplates.templates,
         "EMAC Helpdesk"              -> EmacHelpdeskTemplates.templates,
         "EMAC"                       -> EmacTemplates.templates,

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/dst/DstTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/dst/DstTemplates.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcemailrenderer.templates.dst
+
+import uk.gov.hmrc.hmrcemailrenderer.domain.{MessagePriority, MessageTemplate}
+import uk.gov.hmrc.hmrcemailrenderer.templates.FromAddress
+import uk.gov.hmrc.hmrcemailrenderer.templates.ServiceIdentifier.DigitalServicesTax
+
+object DstTemplates {
+
+  val templates = Seq(
+    MessageTemplate.create(
+        templateId = "dst_registration_accepted",
+        fromAddress = FromAddress.noReply("Digital Services Tax"),
+        service = DigitalServicesTax,
+        subject = "Digital Services Tax Reference Number",
+        plainTemplate = txt.dstRegistrationAccepted.f,
+        htmlTemplate = html.dstRegistrationAccepted.f,
+        priority = Some(MessagePriority.Urgent)
+        ),
+    MessageTemplate.create(
+        templateId = "dst_registration_received",
+        fromAddress = FromAddress.noReply("Digital Services Tax"),
+        service = DigitalServicesTax,
+        subject = "Digital Services Tax application submitted",
+        plainTemplate = txt.dstRegistrationReceived.f,
+        htmlTemplate = html.dstRegistrationReceived.f,
+        priority = Some(MessagePriority.Urgent)
+        )
+    )
+}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/dst/dstRegistrationAccepted.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/dst/dstRegistrationAccepted.scala.html
@@ -1,0 +1,52 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.hmrcemailrenderer.templates.agent.DateFormatter
+@(params: Map[String, Any])
+
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Your Digital Services Tax registration number") {
+
+    <p>Dear @params("companyName")</p>
+
+    <p>We confirm that @params("companyName") is now registered @if(params("groupCompanyName").toString != "unknown"){ on behalf of @params("groupCompanyName")} for the Digital Services Tax.</p>
+
+    <p>Your Digital Services Tax registration number is <span style="font-weight: bold;">@params("dstNumber")</span></p>
+
+    <p>You will need this registration number when you pay the tax.</p>
+
+    <h2>What you must do next</h2>
+
+    <p>You must pay any Digital Services Tax you owe by @DateFormatter.formatDate(params("paymentDeadline").toString)</p>
+
+    <p>You must submit your first return by @DateFormatter.formatDate(params("submitReturnDeadline").toString).</p>
+
+        <h2>Help using this service</h2>
+
+    <p>For help with payments and returns, search GOV.UK for ‘digital services tax’.</p>
+
+    <p>If you need to change your registered details, contact your HMRC Customer Compliance Manager (CCM).</p>
+
+    <p>If you do not know who your CCM is, or do not have one, email @Html("ccgdstmailbox@hmrc.gov.uk").</p>
+
+        <h2>Why you got this email</h2>
+
+    <p>This email address is registered as the email address we can use to contact you about the Digital Services Tax.</p>
+
+    <p>Do not reply to this email.</p>
+
+    <p>From HMRC Digital Services Tax team</p>
+
+}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/dst/dstRegistrationAccepted.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/dst/dstRegistrationAccepted.scala.html
@@ -19,34 +19,58 @@
 
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Your Digital Services Tax registration number") {
 
-    <p>Dear @params("companyName")</p>
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 15px 0;">
+        Dear @params("name")
+    </p>
 
-    <p>We confirm that @params("companyName") is now registered @if(params("groupCompanyName").toString != "unknown"){ on behalf of @params("groupCompanyName")} for the Digital Services Tax.</p>
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 15px 0;">
+        We confirm that @params("name") is now registered @if(params("groupCompanyName").toString != "unknown"){ on behalf of @params("groupCompanyName")} for the Digital Services Tax.
+    </p>
 
-    <p>Your Digital Services Tax registration number is <span style="font-weight: bold;">@params("dstNumber")</span></p>
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 15px 0;">
+        Your Digital Services Tax registration number is <span style="font-weight: bold;">@params("dstNumber")</span>
+    </p>
 
-    <p>You will need this registration number when you pay the tax.</p>
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 15px 0;">
+        You will need this registration number when you pay the tax.
+    </p>
 
     <h2>What you must do next</h2>
 
-    <p>You must pay any Digital Services Tax you owe by @DateFormatter.formatDate(params("paymentDeadline").toString)</p>
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">
+        You must pay any Digital Services Tax you owe by @DateFormatter.formatDate(params("paymentDeadline").toString).
+    </p>
 
-    <p>You must submit your first return by @DateFormatter.formatDate(params("submitReturnDeadline").toString).</p>
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">
+        You must submit your first return by @DateFormatter.formatDate(params("submitReturnDeadline").toString).
+    </p>
 
-        <h2>Help using this service</h2>
+    <h2>Help using this service</h2>
 
-    <p>For help with payments and returns, search GOV.UK for ‘digital services tax’.</p>
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">
+        For help with payments and returns, search GOV.UK for ‘digital services tax’.
+    </p>
 
-    <p>If you need to change your registered details, contact your HMRC Customer Compliance Manager (CCM).</p>
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">
+        If you need to change your registered details, contact your HMRC Customer Compliance Manager (CCM).
+    </p>
 
-    <p>If you do not know who your CCM is, or do not have one, email @Html("ccgdstmailbox@hmrc.gov.uk").</p>
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">
+        If you do not know who your CCM is, or do not have one, email @Html("ccgdstmailbox@hmrc.gov.uk")
+    </p>
 
-        <h2>Why you got this email</h2>
+    <h2>Why you got this email</h2>
 
-    <p>This email address is registered as the email address we can use to contact you about the Digital Services Tax.</p>
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">
+        This email address is registered as the email address we can use to contact you about the Digital Services Tax.
+    </p>
 
-    <p>Do not reply to this email.</p>
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">
+        Do not reply to this email.
+    </p>
 
-    <p>From HMRC Digital Services Tax team</p>
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">
+        From HMRC Digital Services Tax team
+    </p>
 
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/dst/dstRegistrationAccepted.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/dst/dstRegistrationAccepted.scala.txt
@@ -1,0 +1,34 @@
+@import uk.gov.hmrc.hmrcemailrenderer.templates.agent.DateFormatter
+@(params: Map[String, Any])Your Digital Services Tax registration number.
+
+    Dear @params("companyName")
+
+    We confirm that @params("companyName") is now registered @if(params("groupCompanyName").toString != "unknown"){ on behalf of @params("groupCompanyName")} for the Digital Services Tax.
+
+    Your Digital Services Tax registration number is @params("dstNumber")
+
+    You will need this registration number when you pay the tax.
+
+    What you must do next
+
+    You must pay any Digital Services Tax you owe by @DateFormatter.formatDate(params("paymentDeadline").toString)
+
+    You must submit your first return by @DateFormatter.formatDate(params("submitReturnDeadline").toString).
+
+    Help using this service
+
+    For help with payments and returns, search GOV.UK for ‘digital services tax’.
+
+    If you need to change your registered details, contact your HMRC Customer Compliance Manager (CCM).
+
+    If you do not know who your CCM is, or do not have one, email @Html("ccgdstmailbox@hmrc.gov.uk").
+
+    Why you got this email
+
+    This email address is registered as the email address we can use to contact you about the Digital Services Tax.
+
+    Do not reply to this email.
+
+    From HMRC Digital Services Tax team
+
+@{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer()}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/dst/dstRegistrationAccepted.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/dst/dstRegistrationAccepted.scala.txt
@@ -1,9 +1,9 @@
 @import uk.gov.hmrc.hmrcemailrenderer.templates.agent.DateFormatter
 @(params: Map[String, Any])Your Digital Services Tax registration number.
 
-    Dear @params("companyName")
+    Dear @params("name")
 
-    We confirm that @params("companyName") is now registered @if(params("groupCompanyName").toString != "unknown"){ on behalf of @params("groupCompanyName")} for the Digital Services Tax.
+    We confirm that @params("name") is now registered @if(params("groupCompanyName").toString != "unknown"){ on behalf of @params("groupCompanyName")} for the Digital Services Tax.
 
     Your Digital Services Tax registration number is @params("dstNumber")
 
@@ -21,7 +21,7 @@
 
     If you need to change your registered details, contact your HMRC Customer Compliance Manager (CCM).
 
-    If you do not know who your CCM is, or do not have one, email @Html("ccgdstmailbox@hmrc.gov.uk").
+    If you do not know who your CCM is, or do not have one, email @Html("ccgdstmailbox@hmrc.gov.uk")
 
     Why you got this email
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/dst/dstRegistrationReceived.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/dst/dstRegistrationReceived.scala.html
@@ -18,24 +18,40 @@
 
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Digital Services Tax registration received") {
 
-    <p>Dear @params("companyName")</p>
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 15px 0;">
+        Dear @params("name")
+    </p>
 
-    <p>We received your registration for @params("companyName") @if(params("groupCompanyName").toString != "unknown"){on behalf of @params("groupCompanyName")} for the Digital Services Tax.</p>
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 15px 0;">
+        We received your registration for @params("name") @if(params("groupCompanyName").toString != "unknown"){on behalf of @params("groupCompanyName")} for the Digital Services Tax.
+    </p>
 
     <h2>What happens next</h2>
 
-    <p>We will send your Digital Services Tax registration number to this email address in the next 24 hours.</p>
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">
+        We will send your Digital Services Tax registration number to this email address in the next 24 hours.
+    </p>
 
-    <p>Contact your HMRC Customer Compliance Manager (CCM) if you do not receive your registration number.</p>
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">
+        Contact your HMRC Customer Compliance Manager (CCM) if you do not receive your registration number.
+    </p>
 
-    <p>If you do not know who your CCM is, or do not have one, email @Html("ccgdstmailbox@hmrc.gov.uk").</p>
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">
+        If you do not know who your CCM is, or do not have one, email @Html("ccgdstmailbox@hmrc.gov.uk")
+    </p>
 
-        <h2>Why you got this email</h2>
+    <h2>Why you got this email</h2>
 
-    <p>This email address is registered as the email address we can use to contact you about the Digital Services Tax.</p>
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">
+        This email address is registered as the email address we can use to contact you about the Digital Services Tax.
+    </p>
 
-    <p>Do not reply to this email.</p>
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">
+        Do not reply to this email.
+    </p>
 
-    <p>From HMRC Digital Services Tax team</p>
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">
+        From HMRC Digital Services Tax team
+    </p>
 
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/dst/dstRegistrationReceived.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/dst/dstRegistrationReceived.scala.html
@@ -1,0 +1,41 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(params: Map[String, Any])
+
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Digital Services Tax registration received") {
+
+    <p>Dear @params("companyName")</p>
+
+    <p>We received your registration for @params("companyName") @if(params("groupCompanyName").toString != "unknown"){on behalf of @params("groupCompanyName")} for the Digital Services Tax.</p>
+
+    <h2>What happens next</h2>
+
+    <p>We will send your Digital Services Tax registration number to this email address in the next 24 hours.</p>
+
+    <p>Contact your HMRC Customer Compliance Manager (CCM) if you do not receive your registration number.</p>
+
+    <p>If you do not know who your CCM is, or do not have one, email @Html("ccgdstmailbox@hmrc.gov.uk").</p>
+
+        <h2>Why you got this email</h2>
+
+    <p>This email address is registered as the email address we can use to contact you about the Digital Services Tax.</p>
+
+    <p>Do not reply to this email.</p>
+
+    <p>From HMRC Digital Services Tax team</p>
+
+}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/dst/dstRegistrationReceived.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/dst/dstRegistrationReceived.scala.txt
@@ -1,8 +1,8 @@
 @(params: Map[String, Any])Digital Services Tax registration received
 
-Dear @params("companyName")
+Dear @params("name")
 
-    We received your registration for @params("companyName") @if(params("groupCompanyName").toString != "unknown"){on behalf of @params("groupCompanyName")} for the Digital Services Tax.
+    We received your registration for @params("name") @if(params("groupCompanyName").toString != "unknown"){on behalf of @params("groupCompanyName")} for the Digital Services Tax.
 
     What happens next
 
@@ -10,7 +10,7 @@ Dear @params("companyName")
 
     Contact your HMRC Customer Compliance Manager (CCM) if you do not receive your registration number.
 
-    If you do not know who your CCM is, or do not have one, email @Html("ccgdstmailbox@hmrc.gov.uk").
+    If you do not know who your CCM is, or do not have one, email @Html("ccgdstmailbox@hmrc.gov.uk")
 
     Why you got this email
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/dst/dstRegistrationReceived.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/dst/dstRegistrationReceived.scala.txt
@@ -1,0 +1,22 @@
+@(params: Map[String, Any])Digital Services Tax registration received
+
+Dear @params("companyName")
+
+    We received your registration for @params("companyName") @if(params("groupCompanyName").toString != "unknown"){on behalf of @params("groupCompanyName")} for the Digital Services Tax.
+
+    What happens next
+
+    We will send your Digital Services Tax registration number to this email address in the next 24 hours.
+
+    Contact your HMRC Customer Compliance Manager (CCM) if you do not receive your registration number.
+
+    If you do not know who your CCM is, or do not have one, email @Html("ccgdstmailbox@hmrc.gov.uk").
+
+    Why you got this email
+
+    This email address is registered as the email address we can use to contact you about the Digital Services Tax.
+
+    Do not reply to this email.
+
+    From HMRC Digital Services Tax team
+@{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer()}

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
@@ -88,6 +88,7 @@ class TemplateLocatorSpec extends UnitSpec with OneAppPerSuite {
         "DFS",
         "Digital Contact VAT",
         "Digital Tariffs",
+        "DST",
         "Childcare",
         "PAYE",
         "FANDF",
@@ -567,7 +568,9 @@ class TemplateLocatorSpec extends UnitSpec with OneAppPerSuite {
         "tdq_compliance_partially_compliant_invalid_or_missing_connection_method",
         "tdq_compliance_partially_compliant_valid_connection_method",
         "cgtpd_account_created",
-        "cgtpd_private_beta_access"
+        "cgtpd_private_beta_access",
+        "dst_registration_received",
+        "dst_registration_accepted"
       )
     }
   }


### PR DESCRIPTION
…the user submits the registration and another for when we have recieved a callback from Tax Enrolments.