### PR TITLE
DC-2615 - rule out app-base-config issue for prod

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -122,7 +122,21 @@ metrics {
     enabled = true
 }
 
-welshTemplatesByLangPreferences {}
+welshTemplatesByLangPreferences {
+  changeOfEmailAddress="changeOfEmailAddress_cy"
+  verifyEmailAddress="verifyEmailAddress_cy",
+  digitalOptOutConfirmation="digitalOptOutConfirmation_cy",
+  changeOfEmailAddressNewAddress="changeOfEmailAddressNewAddress_cy",
+  newMessageAlert="newMessageAlert_cy",
+  rescindedMessageAlert="rescindedMessageAlert_cy",
+  verificationReminder="verificationReminder_cy",
+  tax_estimate_message_alert="tax_estimate_message_alert_cy",
+  annual_tax_summaries_message_alert="annual_tax_summaries_message_alert_cy",
+  seiss_processing_grant="seiss_processing_grant_cy",
+  agent_services_account_created="agent_services_account_created_cy",
+  seiss_payment_failed="seiss_payment_failed_cy",
+  digitalOptInConfirmation_PTA="digitalOptInConfirmation_PTA_cy"
+}
 
 # Microservice specific config
 


### PR DESCRIPTION
Need to rule out a possible issue with app-config-base/hmrc-email-renderer.conf not being applied in production only - Welsh emails not being sent out