### PR TITLE
DL-3898 AWRS Email Template Change

### DIFF
--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/awrs/awrsNotificationConfirmationAPI4.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/awrs/awrsNotificationConfirmationAPI4.scala.html
@@ -29,6 +29,7 @@
         </ul>
     </p>
     <p @pStyle>More detailed information can be found in the guidance on GOV.UK.</p>
+    <p @pStyle><strong>HMRC will delete your Government Gateway user ID after 3 years if you do not use it.</strong> Keep your user ID active by signing in regularly.</p>
     <p @pStyle>Remember to keep your Government Gateway user ID and password safe as you will need them if you need to make changes. If your circumstances change you must update your application.</p>
     <p @pStyle>Excise Notice 2002 Section 10.4 has a full list of changes and the circumstances where you need to immediately inform us.</p>
     <p @pStyle>From the HMRC Alcohol Wholesaler Registration Scheme</p>

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/awrs/awrsNotificationConfirmationAPI4.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/awrs/awrsNotificationConfirmationAPI4.scala.txt
@@ -14,6 +14,8 @@ What happens next
 
 More detailed information can be found in the guidance on GOV.UK.
 
+HMRC will delete your Government Gateway user ID after 3 years if you do not use it. Keep your user ID active by signing in regularly.
+
 Remember to keep your Government Gateway user ID and password safe as you will need them if you need to make changes. If your circumstances change you must update your application.
 
 Excise Notice 2002 Section 10.4 has a full list of changes and the circumstances where you need to immediately inform us.

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/awrs/awrsNotificationEmailAppChange.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/awrs/awrsNotificationEmailAppChange.scala.html
@@ -20,6 +20,7 @@
     <p @pStyle>We’ve updated your AWRS application status.</p>
     <p @pStyle>To view it, sign in to your HMRC online account.</p>
     <p @pStyle>For security reasons, we have not included a link with this email.</p>
+    <p @pStyle><strong>HMRC will delete your Government Gateway user ID after 3 years if you do not use it.</strong> Keep your user ID active by signing in regularly.</p>
     <p @pStyle>From the HMRC Alcohol Wholesaler Registration Scheme</p>
 }
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/awrs/awrsNotificationEmailAppChange.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/awrs/awrsNotificationEmailAppChange.scala.txt
@@ -9,6 +9,8 @@ To view it, sign in to your HMRC online account.
 
 For security reasons, we have not included a link with this email.
 
+HMRC will delete your Government Gateway user ID after 3 years if you do not use it. Keep your user ID active by signing in regularly.
+
 From the HMRC Alcohol Wholesaler Registration Scheme
 
 @{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer()}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/awrs/awrsNotificationEmailRegChange.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/awrs/awrsNotificationEmailRegChange.scala.html
@@ -20,6 +20,7 @@
     <p @pStyle>We’ve updated your AWRS registration status.</p>
     <p @pStyle>To view it, sign in to your HMRC online account.</p>
     <p @pStyle>For security reasons, we have not included a link with this email.</p>
+    <p @pStyle><strong>HMRC will delete your Government Gateway user ID after 3 years if you do not use it.</strong> Keep your user ID active by signing in regularly.</p>
     <p @pStyle>From the HMRC Alcohol Wholesaler Registration Scheme</p>
 }
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/awrs/awrsNotificationEmailRegChange.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/awrs/awrsNotificationEmailRegChange.scala.txt
@@ -9,6 +9,8 @@ To view it, sign in to your HMRC online account.
 
 For security reasons, we have not included a link with this email.
 
+HMRC will delete your Government Gateway user ID after 3 years if you do not use it. Keep your user ID active by signing in regularly.
+
 From the HMRC Alcohol Wholesaler Registration Scheme
 
 @{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer()}


### PR DESCRIPTION
AWRS Email Login Reminder Content

All users who have not logged in within the last three years will have their credentials deleted as part of a Government Gateway cleanup operation.

AWRS send out emails which can be used to remind users the need to log in to the service and so some content needs to be written up

Updated email content to to ensure users are reminded to login periodically so that we can ensure their credentials are not deleted as part of any credential cleanup operations

Relates to : https://jira.tools.tax.service.gov.uk/browse/DL-3898

![AwrsApi4](https://user-images.githubusercontent.com/50663032/95467899-e69ffb80-0975-11eb-9ec1-8cf0b8035d7f.png)

![AwrsAppChange](https://user-images.githubusercontent.com/50663032/95467900-e7389200-0975-11eb-9391-ec1e521c60cf.png)

![AwrsRegChange](https://user-images.githubusercontent.com/50663032/95467901-e7d12880-0975-11eb-8277-baf306af75bc.png)

![screencapture-localhost-8950-hmrc-email-renderer-test-only-preview-html-awrs-notification-template-comfirmation-api4-2020-10-08-14_51_44](https://user-images.githubusercontent.com/50663032/95467904-e869bf00-0975-11eb-9d43-1100a122f687.png)



