### PR TITLE
DL-4451 - Added new empty_turn_around_time template

### DIFF
--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -368,6 +368,18 @@ object TemplateParams {
       "paragraphTwo"        -> "If you’re not entitled to a refund we will write and explain the reason why",
       "warningInformation"  -> "true"
     ),
+    "dfs_submission_success_empty_turn_around_time_2020" -> Map(
+      "subject"             -> "Test Subject",
+      "heading"             -> "Test Heading",
+      "greeting"            -> "Mr Joe Bloggs",
+      "confirmation"        -> "HM Revenue and Customs (HMRC) has received your claim for a tax refund",
+      "submissionReference" -> "1234",
+      "paragraphOne"        -> "If you’re entitled to a refund we will send you a revised tax calculation and pay you what you’re owed",
+      "paragraphTwo"        -> "If you’re not entitled to a refund we will write and explain the reason why",
+      "paragraphThree"      -> "If you've asked us to write to you, we'll send you a letter within 15 working days",
+      "paragraphFour"       -> "Some extra content for paragraph four...",
+      "warningInformation"  -> "true"
+    ),
     "dfs_admin_notification" -> Map.empty[String, String],
     "generic_access_invitation_template_id" -> Map(
       "verificationLink" -> exampleLinkWithRandomId

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/dfs/DfsTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/dfs/DfsTemplates.scala
@@ -131,6 +131,15 @@ object DfsTemplates {
       htmlTemplate = html.dfsSubmissionConfirmationEmailEmptyTurnAroundTime_welsh.f,
       priority = Some(MessagePriority.Urgent)
     ),
+    MessageTemplate.createWithDynamicSubject(
+      templateId = "dfs_submission_success_empty_turn_around_time_2020",
+      fromAddress = govUkTeamAddress,
+      service = DigitalFormsService,
+      subject = _.apply("subject"),
+      plainTemplate = txt.dfsSubmissionConfirmationEmailGeneric4ParagraphsEmptyTurnAroundTime.f,
+      htmlTemplate = html.dfsSubmissionConfirmationEmailGeneric4ParagraphsEmptyTurnAroundTime.f,
+      priority = Some(MessagePriority.Urgent)
+    ),
     MessageTemplate.create(
       templateId = "dfs_admin_notification",
       fromAddress = govUkTeamAddress,

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/dfs/dfsSubmissionConfirmationEmailGeneric4ParagraphsEmptyTurnAroundTime.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/dfs/dfsSubmissionConfirmationEmailGeneric4ParagraphsEmptyTurnAroundTime.scala.html
@@ -1,0 +1,58 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(params: Map[String, Any])@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, params("heading").toString) {
+
+
+@if(!params("greeting").asInstanceOf[String].isEmpty) {
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Dear @{params("greeting")}</p>
+
+}
+
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">@{params("confirmation")}.</p>
+
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Your reference is: <b>@{params("submissionReference")}</b></p>
+<br/>
+<h2 style="margin: 0 0 30px; font-size: 24px;">What happens next</h2>
+
+@if(params.isDefinedAt("paragraphOne")) {
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">@{
+    params("paragraphOne")
+    }.</p>
+}
+@if(params.isDefinedAt("paragraphTwo")) {
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">@{
+    params("paragraphTwo")
+    }.</p>
+}
+@if(params.isDefinedAt("paragraphThree")) {
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">@{
+    params("paragraphThree")
+    }.</p>
+}
+@if(params.isDefinedAt("paragraphFour")) {
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">@{
+    params("paragraphFour")
+    }.</p>
+}
+@if(params.get("warningInformation").exists(_ == "true")) {
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">If we need any further details, we'll contact you by letter or phone.</p>
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">We may ask you to sign into a service to provide more details, but we will not ask for your personal details by email.</p>
+}
+<br/>
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">From HMRC</p>
+
+}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/dfs/dfsSubmissionConfirmationEmailGeneric4ParagraphsEmptyTurnAroundTime.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/dfs/dfsSubmissionConfirmationEmailGeneric4ParagraphsEmptyTurnAroundTime.scala.txt
@@ -1,0 +1,31 @@
+@(params: Map[String, Any])@{params("heading")}
+
+
+@if(params("greeting").asInstanceOf[String].length>0) {Dear @{params("greeting")}}
+
+@{params("confirmation")}.
+
+Your reference is: @{params("submissionReference")}
+
+
+
+What happens next
+
+@if(params.isDefinedAt("paragraphOne")) {@{params("paragraphOne")}.}
+
+@if(params.isDefinedAt("paragraphTwo")) {@{params("paragraphTwo")}.}
+
+@if(params.isDefinedAt("paragraphThree")) {@{params("paragraphThree")}.}
+
+@if(params.isDefinedAt("paragraphFour")) {@{params("paragraphFour")}.}
+
+@if(params("warningInformation").equals("true")) {If we need any further details, we'll contact you by letter or phone.
+
+We may ask you to sign into a service to provide more details, but we will not ask for your personal details by email.} 
+
+
+From HMRC
+
+
+
+@{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer()}

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
@@ -229,6 +229,7 @@ class TemplateLocatorSpec extends UnitSpec with OneAppPerSuite {
         "dfs_submission_success_generic_2017_welsh",
         "dfs_submission_success_empty_turn_around_time_2015",
         "dfs_submission_success_empty_turn_around_time_2015_welsh",
+        "dfs_submission_success_empty_turn_around_time_2020",
         "dfs_admin_notification",
         "dfs_admin_notification_welsh",
         "dfs_trusts_submission_success",


### PR DESCRIPTION
Added a new DFS email template for generic 4 paragraph messages with no turn around time.
![p87-email-amended](https://user-images.githubusercontent.com/56881842/100482300-e529be80-30ee-11eb-9af8-ca3b563fd489.png)