### PR TITLE
DL-4036rebase Updated agent removes client template

### DIFF
--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -651,7 +651,8 @@ object TemplateParams {
       "service" -> testServiceUpdate
     ),
     "agent_removes_mandate" -> Map(
-      "service" -> testServiceUpdate
+      "service"      -> testServiceUpdate,
+      "uniqueAuthNo" -> "123456789"
     ),
     "client_removes_mandate" -> Map(
       "service" -> testServiceUpdate

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/mandate/MandateTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/mandate/MandateTemplates.scala
@@ -54,7 +54,7 @@ object MandateTemplates {
       templateId = "agent_removes_mandate",
       fromAddress = govUkTeamAddress,
       service = Mandate,
-      subject = "Your agent has removed you as a client",
+      subject = "Your agent removed you as a client",
       plainTemplate = txt.mandateAgentRemoves.f,
       htmlTemplate = html.mandateAgentRemoves.f,
       priority = Some(MessagePriority.Urgent)

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/mandate/mandateAgentRemoves.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/mandate/mandateAgentRemoves.scala.html
@@ -16,9 +16,15 @@
 
 @(params: Map[String, Any])
 
-@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, params("service").toString + " update") {
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Update to " + params("service").toString) {
 
-    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Your agent has removed you as their client for the @{params("service")}. If you think this is an error, ask your agent to add your company details again.</p>
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Your agent has removed you as their client for the @{params("service")}.</p>
+
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">If you think this is an error, ask your agent to add your company details again.</p>
+
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Your unique authorisation number is <strong>@{params("uniqueAuthNo")}</strong>.</p>
+
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">You need to give this number to your new agent.</p>
 
     <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">From HMRC</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/mandate/mandateAgentRemoves.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/mandate/mandateAgentRemoves.scala.txt
@@ -1,8 +1,14 @@
 @(params: Map[String, Any])
 
-@{params("service")} update
+Update to @{params("service")}
 
-Your agent has removed you as their client for the @{params("service")}. If you think this is an error, ask your agent to add your company details again.
+Your agent has removed you as their client for the @{params("service")}.
+
+If you think this is an error, ask your agent to add your company details again.
+
+Your unique authorisation number is @{params("uniqueAuthNo")}.
+
+You need to give this number to your new agent.
 
 From HMRC
 


### PR DESCRIPTION
This PR is rebased on the latest code from hmrc-email-renderer

It should replace the original PR https://github.com/hmrc/hmrc-email-renderer/pull/586 which appeared to fail during build in hmrc-email-renderer-pr-builder

As the original developer is on leave we have had to create a new fork and reapply the changes with a view to this one passing any required scalafmt checks

![image](https://user-images.githubusercontent.com/15211314/97289571-45eb8000-183f-11eb-9c40-1212636b95cd.png)
