### PR TITLE
API-4620: Email to notify users the PPNS Callback URL for their application has changed

### DIFF
--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -175,6 +175,11 @@ object TemplateParams {
       "timeSinceLastUse"        -> "11 months",
       "dateOfScheduledDeletion" -> "1 April 2025"
     ),
+    "ppnsCallbackUrlChangedNotification" -> Map(
+      "applicationName" -> "Test Application",
+      "newCallbackURL" -> "https://some.remote.server/callback",
+      "dateTimeOfChange" -> "28 October 2020 12:23"
+    ),
     "changeOfEmailAddressNewAddress" -> Map(
       "verificationLink" -> exampleLinkWithRandomId
     ),

--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -176,9 +176,9 @@ object TemplateParams {
       "dateOfScheduledDeletion" -> "1 April 2025"
     ),
     "ppnsCallbackUrlChangedNotification" -> Map(
-      "applicationName"  -> "Test Application",
-      "newCallbackURL"   -> "https://some.remote.server/callback",
-      "dateTimeOfChange" -> "28 October 2020 12:23"
+      "applicationName" -> "Test Application",
+      "dateOfChange"    -> "28 October 2020",
+      "timeOfChange"    -> "12:23"
     ),
     "changeOfEmailAddressNewAddress" -> Map(
       "verificationLink" -> exampleLinkWithRandomId

--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -176,8 +176,8 @@ object TemplateParams {
       "dateOfScheduledDeletion" -> "1 April 2025"
     ),
     "ppnsCallbackUrlChangedNotification" -> Map(
-      "applicationName" -> "Test Application",
-      "newCallbackURL" -> "https://some.remote.server/callback",
+      "applicationName"  -> "Test Application",
+      "newCallbackURL"   -> "https://some.remote.server/callback",
       "dateTimeOfChange" -> "28 October 2020 12:23"
     ),
     "changeOfEmailAddressNewAddress" -> Map(

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplates.scala
@@ -200,6 +200,15 @@ object ApiTemplates {
       plainTemplate = txt.apiApplicationToBeDeletedNotification.f,
       htmlTemplate = html.apiApplicationToBeDeletedNotification.f,
       priority = Some(MessagePriority.Standard)
+    ),
+    MessageTemplate.createWithDynamicFromAddress(
+      templateId = "ppnsCallbackUrlChangedNotification",
+      fromAddress = extractFromAddress,
+      service = ApiDeveloperHub,
+      subject = "Changes made to Callback URL",
+      plainTemplate = txt.ppnsCallbackUrlChangedNotification.f,
+      htmlTemplate = html.ppnsCallbackUrlChangedNotification.f,
+      priority = Some(MessagePriority.Urgent) // Email is a mitigation for a security risk, so increased priority
     )
   )
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ppnsCallbackUrlChangedNotification.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ppnsCallbackUrlChangedNotification.scala.html
@@ -16,8 +16,8 @@
 
 @(params: Map[String, Any])
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Changes made to Callback URL") {
- <p style="margin: 0 0 30px; font-size: 19px;">The Callback URL for <strong>@{params("applicationName")}</strong> changed to <strong>@{params("newCallbackURL")}</strong> on <strong>@{params("dateTimeOfChange")}</strong>.</p>
- <p style="margin: 0 0 30px; font-size: 19px;">If you did not expect this change or the Callback URL is incorrect, sign in to the Developer Hub to update the value.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">The Callback URL for <strong>@{params("applicationName")}</strong> was changed on <strong>@{params("dateOfChange")}</strong> at <strong>@{params("timeOfChange")}</strong>.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">If you did not expect this change, sign in to the Developer Hub to check the new value.</p>
  <p style="margin: 0 0 30px; font-size: 19px;">You can protect your account by changing your password and enabling 2-step verification.</p>
  <p style="margin: 0 0 30px; font-size: 19px;">Do not respond to this email. Replies to this email address are not monitored.</p>
  <p style="margin: 0 0 30px; font-size: 19px;">From HMRC @{params.getOrElse("developerHubTitle", "Developer Hub")}</p>

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ppnsCallbackUrlChangedNotification.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ppnsCallbackUrlChangedNotification.scala.html
@@ -1,0 +1,24 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(params: Map[String, Any])
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Changes made to Callback URL") {
+ <p style="margin: 0 0 30px; font-size: 19px;">The Callback URL for <strong>@{params("applicationName")}</strong> changed to <strong>@{params("newCallbackURL")}</strong> on <strong>@{params("dateTimeOfChange")}</strong>.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">If you did not expect this change or the Callback URL is incorrect, sign in to the Developer Hub to update the value.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">You can protect your account by changing your password and enabling 2-step verification.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">Do not respond to this email. Replies to this email address are not monitored.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">From HMRC @{params.getOrElse("developerHubTitle", "Developer Hub")}</p>
+}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ppnsCallbackUrlChangedNotification.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ppnsCallbackUrlChangedNotification.scala.txt
@@ -1,0 +1,13 @@
+@(params: Map[String, Any])Changes made to Callback URL
+
+The Callback URL for @{params("applicationName")} changed to @{params("newCallbackURL")} on @{params("dateTimeOfChange")}.
+
+If you did not expect this change or the Callback URL is incorrect, sign in to the Developer Hub to update the value.
+
+You can protect your account by changing your password and enabling 2-step verification.
+
+Do not respond to this email. Replies to this email address are not monitored.
+
+From HMRC @{params.getOrElse("developerHubTitle", "Developer Hub")}
+
+@{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer()}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ppnsCallbackUrlChangedNotification.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ppnsCallbackUrlChangedNotification.scala.txt
@@ -1,8 +1,8 @@
 @(params: Map[String, Any])Changes made to Callback URL
 
-The Callback URL for @{params("applicationName")} changed to @{params("newCallbackURL")} on @{params("dateTimeOfChange")}.
+The Callback URL for @{params("applicationName")} was changed on @{params("dateOfChange")} at @{params("timeOfChange")}.
 
-If you did not expect this change or the Callback URL is incorrect, sign in to the Developer Hub to update the value.
+If you did not expect this change, sign in to the Developer Hub to check the new value.
 
 You can protect your account by changing your password and enabling 2-step verification.
 

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
@@ -571,6 +571,7 @@ class TemplateLocatorSpec extends UnitSpec with OneAppPerSuite {
         "pods_aft_amended_return_no_change",
         "pods_aft_amended_return_increase",
         "pods_psp_register",
+        "ppnsCallbackUrlChangedNotification",
         "vat",
         "newMessageAlert_2WSM-question",
         "newMessageAlert_2WSM-reply",

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplatesSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplatesSpec.scala
@@ -96,6 +96,11 @@ class ApiTemplatesSpec extends UnitSpec with OneAppPerSuite {
         templateId = "apiApplicationToBeDeletedNotification",
         expectedSubject = "We’re deleting your application",
         expectedPriority = MessagePriority.Standard)
+
+      validateTemplate(
+        templateId = "ppnsCallbackUrlChangedNotification",
+        expectedSubject = "Changes made to Callback URL",
+        expectedPriority = MessagePriority.Urgent)
     }
   }
 


### PR DESCRIPTION
New email templates to notify administrators and developers of a Third Party Application that the Callback URL for their application has changed.