### PR TITLE
DL-5617 New email template for GENCOMPSUB general complaint form.

### DIFF
--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -528,6 +528,16 @@ object TemplateParams {
       "name"                -> "Mr Joe Bloggs",
       "submissionReference" -> "123-ABCD-456"
     ),
+    "dfs_submission_success_gencompsub_2021" -> Map(
+      "subject"             -> "Test subject",
+      "name"                -> "Mr Joe Bloggs",
+      "submissionReference" -> "123-ABCD-456"
+    ),
+    "dfs_submission_success_gencompsub_2021_welsh" -> Map(
+      "subject"             -> "Test Subject",
+      "name"                -> "Mr Joe Bloggs",
+      "submissionReference" -> "123-ABCD-456"
+    ),
     "cato_access_invitation_template_id" -> Map(
       "verificationLink" -> exampleLinkWithRandomId
     ),

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/dfs/DfsTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/dfs/DfsTemplates.scala
@@ -193,6 +193,24 @@ object DfsTemplates {
       plainTemplate = txt.dfsSubmissionConfirmationEmailRCGT_welsh.f,
       htmlTemplate = html.dfsSubmissionConfirmationEmailRCGT_welsh.f,
       priority = Some(MessagePriority.Urgent)
+    ),
+    MessageTemplate.createWithDynamicSubject(
+      templateId = "dfs_submission_success_gencompsub_2021",
+      fromAddress = govUkTeamAddress,
+      service = DigitalFormsService,
+      subject = _.apply("subject"),
+      plainTemplate = txt.dfsSubmissionConfirmationEmailGENCOMPSUB.f,
+      htmlTemplate = html.dfsSubmissionConfirmationEmailGENCOMPSUB.f,
+      priority = Some(MessagePriority.Urgent)
+    ),
+    MessageTemplate.createWithDynamicSubject(
+      templateId = "dfs_submission_success_gencompsub_2021_welsh",
+      fromAddress = govUkTeamAddress,
+      service = DigitalFormsService,
+      subject = _.apply("subject"),
+      plainTemplate = txt.dfsSubmissionConfirmationEmailGENCOMPSUB_welsh.f,
+      htmlTemplate = html.dfsSubmissionConfirmationEmailGENCOMPSUB_welsh.f,
+      priority = Some(MessagePriority.Urgent)
     )
   )
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/dfs/dfsSubmissionConfirmationEmailGENCOMPSUB.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/dfs/dfsSubmissionConfirmationEmailGENCOMPSUB.scala.html
@@ -1,0 +1,34 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(params: Map[String, Any])@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "") {
+    <h2 style="margin: 0 0 30px; font-size: 19px;">You made a complaint about HMRC</h2>
+
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Dear @{params("name")}</p>
+
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">The reference number for your complaint is: @{params("submissionReference")}</p>
+
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">We will include this if we contact you by email or by letter.</p>
+
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">If you asked us to reply by telephone we will call you from a number that begins with 03000, or displays as unknown or withheld.</p>
+
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">If we cannot reach you by telephone, and you have provided an email address, we will email you to arrange a convenient time to talk about your complaint.</p>
+
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">We will handle your complaint fairly, confidentially and investigate the issues thoroughly. We will also keep you informed of the progress of your complaint.</p>
+
+    <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">From HM Revenue and Customs</p>
+
+}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/dfs/dfsSubmissionConfirmationEmailGENCOMPSUB.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/dfs/dfsSubmissionConfirmationEmailGENCOMPSUB.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @(params: Map[String, Any])@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "") {
-    <h2 style="margin: 0 0 30px; font-size: 19px;">You made a complaint about HMRC</h2>
+    <h1 style="margin: 0 0 30px; font-size: 36px;">You made a complaint about HMRC</h1>
 
     <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Dear @{params("name")}</p>
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/dfs/dfsSubmissionConfirmationEmailGENCOMPSUB.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/dfs/dfsSubmissionConfirmationEmailGENCOMPSUB.scala.txt
@@ -1,0 +1,19 @@
+@(params: Map[String, Any])
+
+You made a complaint about HMRC
+
+Dear @{params("name")}
+
+The reference number for your complaint is: @{params("submissionReference")}
+
+We will include this if we contact you by email or by letter.
+
+If you asked us to reply by telephone we will call you from a number that begins with 03000, or displays as unknown or withheld.
+ 
+If we cannot reach you by telephone, and you have provided an email address, we will email you to arrange a convenient time to talk about your complaint.
+ 
+We will handle your complaint fairly, confidentially and investigate the issues thoroughly. We will also keep you informed of the progress of your complaint.
+ 
+From HM Revenue and Customs
+
+@{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer()}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/dfs/dfsSubmissionConfirmationEmailGENCOMPSUB_welsh.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/dfs/dfsSubmissionConfirmationEmailGENCOMPSUB_welsh.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @(params: Map[String, Any])@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "", isWelsh = true) {
-<h2 style="margin: 0 0 30px; font-size: 19px;">Gwnaethoch gŵyn ynghylch CThEM</h2>
+<h1 style="margin: 0 0 30px; font-size: 36px;">Gwnaethoch gŵyn ynghylch CThEM</h1>
 
 <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Annwyl @{params("name")}</p>
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/dfs/dfsSubmissionConfirmationEmailGENCOMPSUB_welsh.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/dfs/dfsSubmissionConfirmationEmailGENCOMPSUB_welsh.scala.html
@@ -1,0 +1,34 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(params: Map[String, Any])@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "", isWelsh = true) {
+<h2 style="margin: 0 0 30px; font-size: 19px;">Gwnaethoch gŵyn ynghylch CThEM</h2>
+
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Annwyl @{params("name")}</p>
+
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Y cyfeirnod ar gyfer eich cwyn yw: @{params("submissionReference")}</p>
+
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Byddwn yn cynnwys hyn os cysylltwn â chi drwy e-bost neu drwy lythyr.</p>
+
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Os gwnaethoch ofyn i ni eich ateb dros y ffôn, byddwn yn eich ffonio o rif sy’n dechrau gyda 03000, neu sy’n dangos fel rhif anhysbys neu rif sydd wedi’i ddal yn ôl.</p>
+
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Os na allwn gael gafael arnoch dros y ffôn a’ch bod wedi rhoi cyfeiriad e-bost i ni, byddwn yn anfon e-bost atoch er mwyn trefnu amser cyfleus i drafod eich cwyn.</p>
+
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Byddwn yn delio â’ch cwyn mewn ffordd deg a chyfrinachol ac yn ymchwilio i’r materion yn drwyadl. Byddwn hefyd yn rhoi’r  rhoi’r diweddaraf i chi am hynt eich cwyn.</p>
+
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Oddi wrth Gyllid a Thollau EM</p>
+
+}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/dfs/dfsSubmissionConfirmationEmailGENCOMPSUB_welsh.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/dfs/dfsSubmissionConfirmationEmailGENCOMPSUB_welsh.scala.txt
@@ -1,0 +1,19 @@
+@(params: Map[String, Any])
+
+Gwnaethoch gŵyn ynghylch CThEM
+
+Annwyl @{params("name")}
+
+Y cyfeirnod ar gyfer eich cwyn yw: @{params("submissionReference")}
+
+Byddwn yn cynnwys hyn os cysylltwn â chi drwy e-bost neu drwy lythyr.
+
+Os gwnaethoch ofyn i ni eich ateb dros y ffôn, byddwn yn eich ffonio o rif sy’n dechrau gyda 03000, neu sy’n dangos fel rhif anhysbys neu rif sydd wedi’i ddal yn ôl.
+ 
+Os na allwn gael gafael arnoch dros y ffôn a’ch bod wedi rhoi cyfeiriad e-bost i ni, byddwn yn anfon e-bost atoch er mwyn trefnu amser cyfleus i drafod eich cwyn.
+ 
+Byddwn yn delio â’ch cwyn mewn ffordd deg a chyfrinachol ac yn ymchwilio i’r materion yn drwyadl. Byddwn hefyd yn rhoi’r  rhoi’r diweddaraf i chi am hynt eich cwyn.
+ 
+Oddi wrth Gyllid a Thollau EM
+
+@{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer_cy()}

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
@@ -241,6 +241,8 @@ class TemplateLocatorSpec extends UnitSpec with OneAppPerSuite {
         "dfs_submission_success_empty_turn_around_time_2015",
         "dfs_submission_success_empty_turn_around_time_2015_welsh",
         "dfs_submission_success_empty_turn_around_time_2020",
+        "dfs_submission_success_gencompsub_2021",
+        "dfs_submission_success_gencompsub_2021_welsh",
         "dfs_admin_notification",
         "dfs_admin_notification_welsh",
         "dfs_trusts_submission_success",


### PR DESCRIPTION
Adding a new email template for DFS service, a general complaint form. the content has been reviewed by content designers from both digital contact and the DDCT live service team. DFS service doesn't use preference service and will choose appropriate email template for welsh email.