### PR TITLE
CMQ-1767 and CMQ-1752

### DIFF
--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -2046,11 +2046,19 @@ object TemplateParams2 {
           """)).getBytes("UTF-8"))
     ),
     "tdq_fph_report_heuristically_compliant" -> Map(
-      "developerName"   -> "John Smith",
-      "fromDate"        -> "22 September 2019",
-      "toDate"          -> "22 October 2019",
-      "applicationName" -> "My Well Behaved MTD App",
-      "applicationId"   -> "c190e3a0-cf8e-402d-ae37-2ec4a54bffff"
+      "developerName"             -> "John Smith",
+      "fromDate"                  -> "22 September 2019",
+      "toDate"                    -> "22 October 2019",
+      "applicationName"           -> "My Well Behaved MTD App",
+      "applicationId"             -> "c190e3a0-cf8e-402d-ae37-2ec4a54bffff",
+      "hasOtherConnectionMethods" -> "true",
+      "extraDetails"              -> Base64.getEncoder.encodeToString(stringify(parse("""
+        {
+          "connectionMethod": "WEB_APP_VIA_SERVER",
+          "requestCount": 10500,
+          "headerValidations": []
+        }
+          """)).getBytes("UTF-8"))
     ),
     "cgtpd_account_created" -> Map(
       "cgtReference" -> "XYCGTP123456780",

--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -2043,7 +2043,7 @@ object TemplateParams2 {
             }
           ]
         }
-          """)).getBytes("UTF-8"))
+        """)).getBytes("UTF-8"))
     ),
     "tdq_fph_report_heuristically_compliant" -> Map(
       "developerName"             -> "John Smith",
@@ -2058,7 +2058,7 @@ object TemplateParams2 {
           "requestCount": 10500,
           "headerValidations": []
         }
-          """)).getBytes("UTF-8"))
+        """)).getBytes("UTF-8"))
     ),
     "cgtpd_account_created" -> Map(
       "cgtReference" -> "XYCGTP123456780",

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/tdq/params/TdqFphReportParams.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/tdq/params/TdqFphReportParams.scala
@@ -27,7 +27,8 @@ final case class TdqFphReportParams(
   allHeadersMissingCount: Int,
   invalidConnectionMethodCount: Int,
   relatesToMultipleVersions: Boolean,
-  extraDetails: Option[ValidConnectionMethodBase64EncodedDetails]
+  extraDetails: Option[ValidConnectionMethodBase64EncodedDetails],
+  hasOtherConnectionMethods: Boolean
 ) {
 
   def hasAllHeadersMissing: Boolean = allHeadersMissingPercentage > 0
@@ -53,7 +54,8 @@ object TdqFphReportParams {
       params.get("allHeadersMissingCount").fold(0)(_.toString.toInt),
       params.get("invalidConnectionMethodCount").fold(0)(_.toString.toInt),
       params.get("relatesToMultipleVersions").fold(false)(_.toString.toBoolean),
-      params.get("extraDetails").map(details => ValidConnectionMethodBase64EncodedDetails.parse(details.toString))
+      params.get("extraDetails").map(details => ValidConnectionMethodBase64EncodedDetails.parse(details.toString)),
+      params.get("hasOtherConnectionMethods").fold(false)(_.toString.toBoolean)
     )
 
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/tdq/params/ValidConnectionMethodBase64EncodedDetails.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/tdq/params/ValidConnectionMethodBase64EncodedDetails.scala
@@ -99,13 +99,15 @@ final case class Problem(message: String, percentage: Int, count: Int) {
 
   val shortPercentageDescription: String =
     if (percentage < 1) {
-      "Fewer than 1% of requests"
+      "Fewer than 1% of total"
     } else {
-      s"$percentage% of requests"
+      s"$percentage% of total"
     }
 
-  val prettyCount: String = Problem.prettyCount(count)
-
+  val prettyCount: String = {
+    val suffix = if (count > 1) "requests" else "request"
+    s"${Problem.prettyCount(count)} $suffix"
+  }
 }
 
 object Problem {

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/tdq/tdqFphReportHeuristicallyCompliant.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/tdq/tdqFphReportHeuristicallyCompliant.scala.html
@@ -16,8 +16,10 @@
 
 @import uk.gov.hmrc.hmrcemailrenderer.templates.tdq.params.TdqFphReportParams
 @(params: Map[String, Any])
+
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Fraud prevention headers report for VAT (Making Tax Digital)") {
     @defining(TdqFphReportParams(params)) { reportParams =>
+
         <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Dear @reportParams.developerName</p>
 
         <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">
@@ -25,10 +27,18 @@
         </p>
 
         <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">
-            Our logs show that all of the fraud prevention headers submitted for <b>@reportParams.applicationName</b> between
-            @reportParams.fromDate and @reportParams.toDate meet the current specification on the HMRC Developer Hub.
-            Thank you, we'll send you a report if this changes.
+            Our logs show that all of the fraud prevention headers submitted for <b>@reportParams.applicationName</b>
+            @for(extraDetails <- reportParams.extraDetails) {
+              using <b>@{extraDetails.prettyConnectionMethod.toLowerCase}</b>
+            }
+            between @reportParams.fromDate and @reportParams.toDate meet the current specification on the HMRC Developer Hub.
         </p>
+
+        @if(reportParams.hasOtherConnectionMethods) {
+            <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">
+                Your application sent requests using another connection method, you'll receive a separate report.
+            </p>
+        }
 
         <h2>Why you have received this email</h2>
         <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/tdq/tdqFphReportHeuristicallyCompliant.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/tdq/tdqFphReportHeuristicallyCompliant.scala.txt
@@ -5,7 +5,9 @@ Dear @reportParams.developerName
 
 To help protect your customers' confidential data from criminals and fraudsters, we monitor API calls and send you feedback every month.
 
-Our logs show that all of the fraud prevention headers submitted for @reportParams.applicationName between @reportParams.fromDate and @reportParams.toDate meet the current specification on the HMRC Developer Hub. Thank you, we'll send you a report if this changes.
+Our logs show that all of the fraud prevention headers submitted for @reportParams.applicationName @for(extraDetails <- reportParams.extraDetails) {using @{extraDetails.prettyConnectionMethod.toLowerCase}} between @reportParams.fromDate and @reportParams.toDate meet the current specification on the HMRC Developer Hub.
+
+@if(reportParams.hasOtherConnectionMethods) {Your application sent requests using another connection method, you'll receive a separate report.}
 
 Why you have received this email
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/tdq/tdqFphReportNonCompliant.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/tdq/tdqFphReportNonCompliant.scala.html
@@ -127,7 +127,7 @@
                                 <tr>
                                     <td style="vertical-align: top; font-size: 19px; line-height: 1.315789474; font-weight: bold; width: 70px;">Error</td>
                                     <td style="vertical-align: top; font-size: 19px; line-height: 1.315789474;">@error.message</td>
-                                    <td style="vertical-align: top; font-size: 19px; line-height: 1.315789474; width: 80px;">@error.prettyCount<br>
+                                    <td style="vertical-align: top; font-size: 19px; line-height: 1.315789474; width: 135px;">@error.prettyCount<br>
                                         @error.shortPercentageDescription</td>
                                 </tr>
                             }
@@ -135,7 +135,7 @@
                                 <tr>
                                     <td style="vertical-align: top; font-size: 19px; line-height: 1.315789474; width: 70px;">Warning</td>
                                     <td style="vertical-align: top; font-size: 19px; line-height: 1.315789474;">@warning.message</td>
-                                    <td style="vertical-align: top; font-size: 19px; line-height: 1.315789474; width: 80px;">@warning.prettyCount<br>
+                                    <td style="vertical-align: top; font-size: 19px; line-height: 1.315789474; width: 135px;">@warning.prettyCount<br>
                                         @warning.shortPercentageDescription</td>
                                 </tr>
                             }


### PR DESCRIPTION
CMQ-1767 Make the request count on errors/warnings clearer in the email sent when a connection method doesn't meet the FPH spec
CMQ-1752 For the email sent when an app's requests for a given connection method are heuristically compliant, include the connection method and an indication that there are other connection methods that email reports will be sent for