### PR TITLE
API-5070 Two new emails for contacting internal API Producer teams

### DIFF
--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -1589,6 +1589,29 @@ object TemplateParams {
     "oss_returns_email_confirmation_no_vat_owed" -> Map(
       "recipientName_line1" -> "Joe Bloggs",
       "period"              -> "1 July to 30 September 2021"
+    ),
+    "platformContact" -> Map(
+      "apiTitle"    -> "Individuals Tax Relief for Kitten Ownership",
+      "senderName"  -> "Alice Example",
+      "senderEmail" -> "alice@example.com",
+      "contactReasons" -> Base64.getEncoder.encodeToString(
+        stringify(parse("""[
+          "I want to know if I can reuse this API",
+          "I need more information, like schemas or examples"
+        ]""")).getBytes("UTF-8")),
+      "specificQuestion" -> "I need some stuff."
+    ),
+    "platformContactConfirmation" -> Map(
+      "apiTitle"    -> "Individuals Tax Relief for Kitten Ownership",
+      "senderName"  -> "Alice Example",
+      "senderEmail" -> "alice@example.com",
+      "contactReasons" -> Base64.getEncoder.encodeToString(
+        stringify(parse("""[
+          "I want to know if I can reuse this API",
+          "I need more information, like schemas or examples"
+        ]""")).getBytes("UTF-8")),
+      "specificQuestion" -> "I need some stuff.",
+      "apiEmail"         -> "api-platform@example.com"
     )
   )
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/ServiceIdentifier.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/ServiceIdentifier.scala
@@ -28,6 +28,7 @@ object ServiceIdentifier {
   case object AntiMoneyLaunderingSupervision extends ServiceIdentifier { override val name = "amls" }
   case object AnnualTaxSummary extends ServiceIdentifier { override val name = "ats" }
   case object ApiDeveloperHub extends ServiceIdentifier { override val name = "api" }
+  case object ApiCatalogue extends ServiceIdentifier { override val name = "api-catalogue" }
   case object BTIOperationalService extends ServiceIdentifier { override val name = "tariff-classification-frontend" }
   case object BTIApplicationService extends ServiceIdentifier { override val name = "binding-tariff-trader-frontend" }
   case object BTIAdviceService extends ServiceIdentifier { override val name = "binding-tariff-advice-frontend" }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocator.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocator.scala
@@ -21,6 +21,7 @@ import uk.gov.hmrc.hmrcemailrenderer.templates.aeo.AEOMRATemplates
 import uk.gov.hmrc.hmrcemailrenderer.templates.agent.AgentTemplates
 import uk.gov.hmrc.hmrcemailrenderer.templates.amls.AmlsTemplates
 import uk.gov.hmrc.hmrcemailrenderer.templates.api.ApiTemplates
+import uk.gov.hmrc.hmrcemailrenderer.templates.apicatalogue.ApiCatalogueTemplates
 import uk.gov.hmrc.hmrcemailrenderer.templates.ated.AtedTemplates
 import uk.gov.hmrc.hmrcemailrenderer.templates.ats.AtsTemplates
 import uk.gov.hmrc.hmrcemailrenderer.templates.awrs.AwrsTemplates
@@ -82,6 +83,7 @@ trait TemplateLocator {
       "AEO MRA"               -> AEOMRATemplates.templates,
       "Agent"                 -> AgentTemplates.templates,
       "API Platform"          -> ApiTemplates.templates,
+      "API Catalogue"         -> ApiCatalogueTemplates.templates,
       "ATS"                   -> AtsTemplates.templates,
       "AWRS"                  -> AwrsTemplates.templates,
       "AMLS"                  -> AmlsTemplates.templates,

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/ApiCatalogueTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/ApiCatalogueTemplates.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcemailrenderer.templates.apicatalogue
+
+import uk.gov.hmrc.hmrcemailrenderer.domain.{ MessagePriority, MessageTemplate }
+import uk.gov.hmrc.hmrcemailrenderer.templates.ServiceIdentifier.ApiCatalogue
+import uk.gov.hmrc.hmrcemailrenderer.templates.FromAddress
+
+/**
+  * Templates used by the API Catalogue.
+  */
+object ApiCatalogueTemplates {
+  val templates = Seq(
+    MessageTemplate.create(
+      templateId = "platformContact",
+      fromAddress = "notsure@example.com", // TODO - what should this be?,
+      service = ApiCatalogue,
+      subject = "Information request from the API catalogue",
+      plainTemplate = txt.platformContact.f,
+      htmlTemplate = html.platformContact.f,
+      priority = Some(MessagePriority.Standard)
+    ),
+    MessageTemplate.create(
+      templateId = "platformContactConfirmation",
+      fromAddress = "notsure@example.com", // TODO - what should this be?,
+      service = ApiCatalogue,
+      subject = "A summary of your message sent from the API catalogue",
+      plainTemplate = txt.platformContactConfirmation.f,
+      htmlTemplate = html.platformContactConfirmation.f,
+      priority = Some(MessagePriority.Standard)
+    )
+  )
+}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/params/ApiCatalogueReportParams.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/params/ApiCatalogueReportParams.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcemailrenderer.templates.apicatalogue.params
+
+import java.util.Base64
+import play.api.libs.json.Json
+object ApiCatalogueReportParams {
+
+  def getQuestions(params: Map[String, Any]): List[String] =
+    params
+      .get("contactReasons")
+      .fold(List.empty[String])(contactReasons => {
+        val encoded = contactReasons.toString
+        val decoded = new String(Base64.getDecoder.decode(encoded), "UTF-8")
+        Json.parse(decoded).as[List[String]]
+      })
+}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/platformContact.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/platformContact.scala.html
@@ -23,7 +23,7 @@
 
   <p style="margin: 0 0 30px; font-size: 19px;">We have received an information request about @{params("apiTitle")} on the API catalogue.</p>
 
-  <p style="margin: 0 0 30px; font-size: 19px;">Here’s a summary.</p>
+  <p style="margin: 0 0 30px; font-size: 19px;">Here is a summary.</p>
 
   <p style="margin: 0 0 30px; font-size: 19px;"><strong>Name</strong>: @{params("senderName")}</p>
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/platformContact.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/platformContact.scala.html
@@ -19,7 +19,9 @@
 @(params: Map[String, Any])
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Information request about " + params("apiTitle")) { 
 
-  <p style="margin: 0 0 30px; font-size: 19px;">We’ve received an information request about @{params("apiTitle")} on the API catalogue.</p>
+  <p style="margin: 0 0 30px; font-size: 19px;">Dear platform team</p>
+
+  <p style="margin: 0 0 30px; font-size: 19px;">We have received an information request about @{params("apiTitle")} on the API catalogue.</p>
 
   <p style="margin: 0 0 30px; font-size: 19px;">Here’s a summary.</p>
 
@@ -41,5 +43,7 @@
 
   <p style="margin: 0 0 30px; font-size: 19px;">@{params("specificQuestion")}</p>
 
-  <p style="margin: 0 0 30px; font-size: 19px;">You should reply to @{params("senderEmail")} in 7 days. </p>
+  <p style="margin: 0 0 30px; font-size: 19px;">You should reply to @{params("senderEmail")} in 7 days.</p>
+
+  <p style="margin: 0 0 30px; font-size: 19px;">From HMRC API catalogue</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/platformContact.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/platformContact.scala.html
@@ -1,0 +1,45 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.hmrcemailrenderer.templates.apicatalogue.params.ApiCatalogueReportParams.getQuestions
+
+@(params: Map[String, Any])
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Information request about " + params("apiTitle")) { 
+
+  <p style="margin: 0 0 30px; font-size: 19px;">We’ve received an information request about @{params("apiTitle")} on the API catalogue.</p>
+
+  <p style="margin: 0 0 30px; font-size: 19px;">Here’s a summary.</p>
+
+  <p style="margin: 0 0 30px; font-size: 19px;"><strong>Name</strong>: @{params("senderName")}</p>
+
+  <p style="margin: 0 0 30px; font-size: 19px;"><strong>Email</strong>: @{params("senderEmail")}</p>
+
+  @defining(getQuestions(params)) { questions =>
+    @if(questions.nonEmpty){
+      <p style="margin: 0 0 30px; font-size: 19px;"><strong>Why do you need to contact the API team?</strong></p>
+
+      @for(question <- questions){
+        <p style="margin: 0 0 30px; font-size: 19px;">@question</p>
+      }
+    }
+  }
+  
+  <p style="margin: 0 0 30px; font-size: 19px;"><strong>Do you have a specific question?</strong></p>
+
+  <p style="margin: 0 0 30px; font-size: 19px;">@{params("specificQuestion")}</p>
+
+  <p style="margin: 0 0 30px; font-size: 19px;">You should reply to @{params("senderEmail")} in 7 days. </p>
+}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/platformContact.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/platformContact.scala.txt
@@ -5,7 +5,7 @@ Dear platform team
 
 We have received an information request about @{params("apiTitle")} on the API catalogue. 
 
-Here’s a summary.
+Here is a summary.
 
 Name: @{params("senderName")}
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/platformContact.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/platformContact.scala.txt
@@ -1,0 +1,25 @@
+@import uk.gov.hmrc.hmrcemailrenderer.templates.apicatalogue.params.ApiCatalogueReportParams.getQuestions
+@(params: Map[String, Any])Information request about @{params("apiTitle")}
+
+We’ve received an information request about @{params("apiTitle")} on the API catalogue. 
+
+Here’s a summary.
+
+Name: @{params("senderName")}
+
+Email: @{params("senderEmail")}
+@defining(getQuestions(params)){ questions =>
+@if(questions.nonEmpty){
+
+Why do you need to contact the API team?
+@for(question <- questions){
+  @question
+}
+
+}}
+Do you have a specific question?
+
+  @{params("specificQuestion")}
+
+
+You should reply to @{params("senderEmail")} in 7 days. 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/platformContact.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/platformContact.scala.txt
@@ -1,7 +1,9 @@
 @import uk.gov.hmrc.hmrcemailrenderer.templates.apicatalogue.params.ApiCatalogueReportParams.getQuestions
 @(params: Map[String, Any])Information request about @{params("apiTitle")}
 
-We’ve received an information request about @{params("apiTitle")} on the API catalogue. 
+Dear platform team
+
+We have received an information request about @{params("apiTitle")} on the API catalogue. 
 
 Here’s a summary.
 
@@ -23,3 +25,5 @@ Do you have a specific question?
 
 
 You should reply to @{params("senderEmail")} in 7 days. 
+
+From HMRC API catalogue

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/platformContactConfirmation.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/platformContactConfirmation.scala.html
@@ -17,9 +17,11 @@
 @import uk.gov.hmrc.hmrcemailrenderer.templates.apicatalogue.params.ApiCatalogueReportParams.getQuestions
 
 @(params: Map[String, Any])
-@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "We’ve sent your message") { 
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "We have sent your message") { 
 
-  <p style="margin: 0 0 30px; font-size: 19px;">Here’s a summary.</p>
+  <p style="margin: 0 0 30px; font-size: 19px;">Dear @{params("senderName")}</p>
+
+  <p style="margin: 0 0 30px; font-size: 19px;">Here is a summary of your message sent to the platform team.</p>
 
   <p style="margin: 0 0 30px; font-size: 19px;"><strong>API</strong>: @{params("apiTitle")}</p>
 
@@ -44,4 +46,6 @@
   <p style="margin: 0 0 30px; font-size: 19px;"><strong>Sent to:</strong> @{params("apiEmail")}</p>
   
   <p style="margin: 0 0 30px; font-size: 19px;">You should get a reply in 7 days.</p>
+
+  <p style="margin: 0 0 30px; font-size: 19px;">From HMRC API catalogue</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/platformContactConfirmation.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/platformContactConfirmation.scala.html
@@ -1,0 +1,47 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.hmrcemailrenderer.templates.apicatalogue.params.ApiCatalogueReportParams.getQuestions
+
+@(params: Map[String, Any])
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "We’ve sent your message") { 
+
+  <p style="margin: 0 0 30px; font-size: 19px;">Here’s a summary.</p>
+
+  <p style="margin: 0 0 30px; font-size: 19px;"><strong>API</strong>: @{params("apiTitle")}</p>
+
+  <p style="margin: 0 0 30px; font-size: 19px;"><strong>Name</strong>: @{params("senderName")}</p>
+
+  <p style="margin: 0 0 30px; font-size: 19px;"><strong>Email</strong>: @{params("senderEmail")}</p>
+
+  @defining(getQuestions(params)) { questions =>
+    @if(questions.nonEmpty){
+      <p style="margin: 0 0 30px; font-size: 19px;"><strong>Why do you need to contact the API team?</strong></p>
+
+      @for(question <- questions){
+        <p style="margin: 0 0 30px; font-size: 19px;">@question</p>
+      }
+    }
+  }
+
+  <p style="margin: 0 0 30px; font-size: 19px;"><strong>Do you have a specific question?</strong></p>
+
+  <p style="margin: 0 0 30px; font-size: 19px;">@{params("specificQuestion")}</p>
+
+  <p style="margin: 0 0 30px; font-size: 19px;"><strong>Sent to:</strong> @{params("apiEmail")}</p>
+  
+  <p style="margin: 0 0 30px; font-size: 19px;">You should get a reply in 7 days.</p>
+}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/platformContactConfirmation.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/platformContactConfirmation.scala.txt
@@ -1,0 +1,27 @@
+@import uk.gov.hmrc.hmrcemailrenderer.templates.apicatalogue.params.ApiCatalogueReportParams.getQuestions
+@(params: Map[String, Any])We’ve sent your message
+
+Here’s a summary.
+
+API: @{params("apiTitle")}
+
+Name: @{params("senderName")}
+
+Email: @{params("senderEmail")}
+@defining(getQuestions(params)){ questions =>
+@if(questions.nonEmpty){
+
+Why do you need to contact the API team?
+@for(question <- questions){
+  @question
+}
+
+}}
+Do you have a specific question?
+
+  @{params("specificQuestion")}
+
+
+Sent to: @{params("apiEmail")}
+
+You should get a reply in 7 days.

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/platformContactConfirmation.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/apicatalogue/platformContactConfirmation.scala.txt
@@ -1,7 +1,9 @@
 @import uk.gov.hmrc.hmrcemailrenderer.templates.apicatalogue.params.ApiCatalogueReportParams.getQuestions
-@(params: Map[String, Any])We’ve sent your message
+@(params: Map[String, Any])We have sent your message
 
-Here’s a summary.
+Dear @{params("senderName")}
+
+Here is a summary of your message sent to the platform team.
 
 API: @{params("apiTitle")}
 
@@ -25,3 +27,5 @@ Do you have a specific question?
 Sent to: @{params("apiEmail")}
 
 You should get a reply in 7 days.
+
+From HMRC API catalogue

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
@@ -116,7 +116,8 @@ class TemplateLocatorSpec extends WordSpecLike with Matchers with OptionValues w
         "Exports (CDS)",
         "MODS",
         "CDSRC",
-        "OSS"
+        "OSS",
+        "API Catalogue"
       )
     }
 
@@ -750,7 +751,9 @@ class TemplateLocatorSpec extends WordSpecLike with Matchers with OptionValues w
         "oss_registration_confirmation_pre_10th_of_month",
         "oss_registration_confirmation_post_10th_of_month",
         "oss_returns_email_confirmation",
-        "oss_returns_email_confirmation_no_vat_owed"
+        "oss_returns_email_confirmation_no_vat_owed",
+        "platformContact",
+        "platformContactConfirmation"
       )
     }
   }


### PR DESCRIPTION
For the API catalogue to contact internal HMRC API producer teams via email