### PR TITLE
APIS-5752 - Update existing and add new Responsible Individual email templates

### DIFF
--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -202,7 +202,8 @@ object TemplateParams {
     "apiVerifyResponsibleIndividual" -> Map(
       "developerHubLink"          -> exampleLinkWithRandomId,
       "applicationName"           -> "Test Application",
-      "responsibleIndividualName" -> "Joe Bloggs"
+      "responsibleIndividualName" -> "Joe Bloggs",
+      "requesterName"             -> "Bob Roberts"
     ),
     "ppnsCallbackUrlChangedNotification" -> Map(
       "applicationName" -> "Test Application",

--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -210,6 +210,11 @@ object TemplateParams {
       "responsibleIndividualName" -> "Joe Bloggs",
       "requesterName"             -> "Bob Roberts"
     ),
+    "apiResponsibleIndividualDeclined" -> Map(
+      "applicationName"           -> "Test Application",
+      "responsibleIndividualName" -> "Joe Bloggs",
+      "requesterName"             -> "Bob Roberts"
+    ),
     "ppnsCallbackUrlChangedNotification" -> Map(
       "applicationName" -> "Test Application",
       "dateOfChange"    -> "28 October 2020",

--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -205,6 +205,11 @@ object TemplateParams {
       "responsibleIndividualName" -> "Joe Bloggs",
       "requesterName"             -> "Bob Roberts"
     ),
+    "apiResponsibleIndividualReminderToAdmin" -> Map(
+      "applicationName"           -> "Test Application",
+      "responsibleIndividualName" -> "Joe Bloggs",
+      "requesterName"             -> "Bob Roberts"
+    ),
     "ppnsCallbackUrlChangedNotification" -> Map(
       "applicationName" -> "Test Application",
       "dateOfChange"    -> "28 October 2020",

--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -215,6 +215,11 @@ object TemplateParams {
       "responsibleIndividualName" -> "Joe Bloggs",
       "requesterName"             -> "Bob Roberts"
     ),
+    "apiResponsibleIndividualDidNotVerify" -> Map(
+      "applicationName"           -> "Test Application",
+      "responsibleIndividualName" -> "Joe Bloggs",
+      "requesterName"             -> "Bob Roberts"
+    ),
     "ppnsCallbackUrlChangedNotification" -> Map(
       "applicationName" -> "Test Application",
       "dateOfChange"    -> "28 October 2020",

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplates.scala
@@ -218,6 +218,15 @@ object ApiTemplates {
       plainTemplate = txt.apiVerifyResponsibleIndividual.f,
       htmlTemplate = html.apiVerifyResponsibleIndividual.f,
       priority = Some(MessagePriority.Urgent)
+    ),
+    MessageTemplate.createWithDynamicFromAddress(
+      templateId = "apiResponsibleIndividualReminderToAdmin",
+      fromAddress = extractFromAddress,
+      service = ApiDeveloperHub,
+      subject = "Update about your request for production credentials",
+      plainTemplate = txt.apiResponsibleIndividualReminderToAdmin.f,
+      htmlTemplate = html.apiResponsibleIndividualReminderToAdmin.f,
+      priority = Some(MessagePriority.Standard)
     )
   )
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplates.scala
@@ -214,7 +214,7 @@ object ApiTemplates {
       templateId = "apiVerifyResponsibleIndividual",
       fromAddress = extractFromAddress,
       service = ApiDeveloperHub,
-      subject = "Responsible Individual Verification",
+      subject = "Responsible individual verification",
       plainTemplate = txt.apiVerifyResponsibleIndividual.f,
       htmlTemplate = html.apiVerifyResponsibleIndividual.f,
       priority = Some(MessagePriority.Urgent)

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplates.scala
@@ -227,6 +227,15 @@ object ApiTemplates {
       plainTemplate = txt.apiResponsibleIndividualReminderToAdmin.f,
       htmlTemplate = html.apiResponsibleIndividualReminderToAdmin.f,
       priority = Some(MessagePriority.Standard)
+    ),
+    MessageTemplate.createWithDynamicFromAddress(
+      templateId = "apiResponsibleIndividualDeclined",
+      fromAddress = extractFromAddress,
+      service = ApiDeveloperHub,
+      subject = "Production credentials request declined",
+      plainTemplate = txt.apiResponsibleIndividualDeclined.f,
+      htmlTemplate = html.apiResponsibleIndividualDeclined.f,
+      priority = Some(MessagePriority.Standard)
     )
   )
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplates.scala
@@ -232,9 +232,18 @@ object ApiTemplates {
       templateId = "apiResponsibleIndividualDeclined",
       fromAddress = extractFromAddress,
       service = ApiDeveloperHub,
-      subject = "Production credentials request declined",
+      subject = "Important update about your production credentials request",
       plainTemplate = txt.apiResponsibleIndividualDeclined.f,
       htmlTemplate = html.apiResponsibleIndividualDeclined.f,
+      priority = Some(MessagePriority.Urgent)
+    ),
+    MessageTemplate.createWithDynamicFromAddress(
+      templateId = "apiResponsibleIndividualDidNotVerify",
+      fromAddress = extractFromAddress,
+      service = ApiDeveloperHub,
+      subject = "Production credentials request declined",
+      plainTemplate = txt.apiResponsibleIndividualDidNotVerify.f,
+      htmlTemplate = html.apiResponsibleIndividualDidNotVerify.f,
       priority = Some(MessagePriority.Standard)
     )
   )

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiResponsibleIndividualDeclined.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiResponsibleIndividualDeclined.scala.html
@@ -1,0 +1,23 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(params: Map[String, Any])
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Your request for production credentials is declined") {
+<p style="margin: 0 0 30px; font-size: 19px;">Dear @{params("requesterName")}</p>
+<p style="margin: 0 0 30px; font-size: 19px;">We have declined your request for production credentials because @{params("responsibleIndividualName")} did not verify that @{params("applicationName")} conforms to our terms of use.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">You can review and change the responsible individual's details on the Developer Hub and request production credentials again.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">From HMRC Developer Hub</p>
+}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiResponsibleIndividualDeclined.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiResponsibleIndividualDeclined.scala.html
@@ -18,6 +18,7 @@
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Change the details for the responsible individual") {
 <p style="margin: 0 0 30px; font-size: 19px;">Dear @{params("requesterName")}</p>
 <p style="margin: 0 0 30px; font-size: 19px;">@{params("responsibleIndividualName")} has declined responsibility for @{params("applicationName")}.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">We need someone in your organisation to verify that your software conforms to our terms of use.</p>
 <p style="margin: 0 0 30px; font-size: 19px;">You can change the responsible individual's details on the Developer Hub and request production credentials again.</p>
 <p style="margin: 0 0 30px; font-size: 19px;">From HMRC Developer Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiResponsibleIndividualDeclined.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiResponsibleIndividualDeclined.scala.txt
@@ -1,0 +1,11 @@
+@(params: Map[String, Any])Your request for production credentials is declined
+
+Dear @{params("requesterName")}
+
+We have declined your request for production credentials because @{params("responsibleIndividualName")} did not verify that @{params("applicationName")} conforms to our terms of use.
+
+You can review and change the responsible individual's details on the Developer Hub and request production credentials again.
+
+From HMRC Developer Hub
+
+@{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer()}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiResponsibleIndividualDeclined.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiResponsibleIndividualDeclined.scala.txt
@@ -4,6 +4,8 @@ Dear @{params("requesterName")}
 
 @{params("responsibleIndividualName")} has declined responsibility for @{params("applicationName")}.
 
+We need someone in your organisation to verify that your software conforms to our terms of use.
+
 You can change the responsible individual's details on the Developer Hub and request production credentials again.
 
 From HMRC Developer Hub

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiResponsibleIndividualDeclined.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiResponsibleIndividualDeclined.scala.txt
@@ -1,10 +1,10 @@
-@(params: Map[String, Any])Your request for production credentials is declined
+@(params: Map[String, Any])Change the details for the responsible individual
 
 Dear @{params("requesterName")}
 
-We have declined your request for production credentials because @{params("responsibleIndividualName")} did not verify that @{params("applicationName")} conforms to our terms of use.
+@{params("responsibleIndividualName")} has declined responsibility for @{params("applicationName")}.
 
-You can review and change the responsible individual's details on the Developer Hub and request production credentials again.
+You can change the responsible individual's details on the Developer Hub and request production credentials again.
 
 From HMRC Developer Hub
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiResponsibleIndividualDidNotVerify.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiResponsibleIndividualDidNotVerify.scala.html
@@ -15,9 +15,9 @@
  *@
 
 @(params: Map[String, Any])
-@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Change the details for the responsible individual") {
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Your request for production credentials is declined") {
 <p style="margin: 0 0 30px; font-size: 19px;">Dear @{params("requesterName")}</p>
-<p style="margin: 0 0 30px; font-size: 19px;">@{params("responsibleIndividualName")} has declined responsibility for @{params("applicationName")}.</p>
-<p style="margin: 0 0 30px; font-size: 19px;">You can change the responsible individual's details on the Developer Hub and request production credentials again.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">We have declined your request for production credentials because @{params("responsibleIndividualName")} did not verify that @{params("applicationName")} conforms to our terms of use.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">You can review and change the responsible individual's details on the Developer Hub and request production credentials again.</p>
 <p style="margin: 0 0 30px; font-size: 19px;">From HMRC Developer Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiResponsibleIndividualDidNotVerify.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiResponsibleIndividualDidNotVerify.scala.txt
@@ -1,0 +1,11 @@
+@(params: Map[String, Any])Your request for production credentials is declined
+
+Dear @{params("requesterName")}
+
+We have declined your request for production credentials because @{params("responsibleIndividualName")} did not verify that @{params("applicationName")} conforms to our terms of use.
+
+You can review and change the responsible individual's details on the Developer Hub and request production credentials again.
+
+From HMRC Developer Hub
+
+@{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer()}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiResponsibleIndividualReminderToAdmin.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiResponsibleIndividualReminderToAdmin.scala.html
@@ -1,0 +1,24 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(params: Map[String, Any])
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Check responsible individual details are correct") {
+<p style="margin: 0 0 30px; font-size: 19px;">Dear @{params("requesterName")}</p>
+<p style="margin: 0 0 30px; font-size: 19px;">@{params("responsibleIndividualName")} has not verified that the @{params("applicationName")} software conforms to our terms of use.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">The responsible individual has 10 working days from today to verify. After that, we will decline your request for production credentials.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">Check or update the responsible individual's details on the Developer Hub and request production credentials again. Or speak to the person you nominated and ask them to verify.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">From HMRC Developer Hub</p>
+}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiResponsibleIndividualReminderToAdmin.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiResponsibleIndividualReminderToAdmin.scala.txt
@@ -1,0 +1,13 @@
+@(params: Map[String, Any])Check responsible individual details are correct
+
+Dear @{params("requesterName")}
+
+@{params("responsibleIndividualName")} has not verified that the @{params("applicationName")} software conforms to our terms of use.
+
+The responsible individual has 10 working days from today to verify. After that, we will decline your request for production credentials.
+
+Check or update the responsible individual's details on the Developer Hub and request production credentials again. Or speak to the person you nominated and ask them to verify.
+
+From HMRC Developer Hub
+
+@{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer()}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiVerifyResponsibleIndividual.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiVerifyResponsibleIndividual.scala.html
@@ -17,11 +17,9 @@
 @(params: Map[String, Any])
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "You are now responsible for a Developer Hub application") {
 <p style="margin: 0 0 30px; font-size: 19px;">Dear @{params("responsibleIndividualName")}</p>
-<p style="margin: 0 0 30px; font-size: 19px;">You have been made responsible for @{params("applicationName")} on the HMRC Developer Hub.</p>
-<p style="margin: 0 0 30px; font-size: 19px;">Select the link to verify that you are responsible for @{params("applicationName")}.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">You have been made responsible for @{params("applicationName")} by @{params("requesterName")} on the HMRC Developer Hub. You must make sure that your software conforms to our terms of use.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">Select the link and tell us if you are responsible for @{params("applicationName")}. Do not forward this email to someone else.</p>
 <p style="margin: 0 0 30px; font-size: 19px;"><a href="@{params("developerHubLink")}" style="padding-bottom:10px;color:#005ea5;text-decoration:underline;">@{params("developerHubLink")}</a></p>
-<p style="margin: 0 0 30px; font-size: 19px;">You have 10 working days to verify that you are responsible for @{params("applicationName")}. After that, you will need to request production access again.</p>
-<p style="margin: 0 0 30px; font-size: 19px;">As the person responsible for @{params("applicationName")}, you must make sure that your software conforms to our terms of use.</p>
-<p style="margin: 0 0 30px; font-size: 19px;">Contact the person who requested credentials for @{params("applicationName")} if you think there has been a mistake or you do not want to verify.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">The link expires in 10 working days. After that, you may need to request production access again.</p>
 <p style="margin: 0 0 30px; font-size: 19px;">From HMRC Developer Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiVerifyResponsibleIndividual.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiVerifyResponsibleIndividual.scala.txt
@@ -2,17 +2,13 @@
 
 Dear @{params("responsibleIndividualName")}
 
-You have been made responsible for @{params("applicationName")} on the HMRC Developer Hub.
+You have been made responsible for @{params("applicationName")} by @{params("requesterName")} on the HMRC Developer Hub. You must make sure that your software conforms to our terms of use.
 
-Select the link to verify that you are responsible for @{params("applicationName")}.
+Select the link and tell us if you are responsible for @{params("applicationName")}. Do not forward this email to someone else.
 
 @{params("developerHubLink")}
 
-You have 10 working days to verify that you are responsible for @{params("applicationName")}. After that, you will need to request production access again
-
-As the person responsible for @{params("applicationName")}, you must make sure that your software conforms to our terms of use.
-
-Contact the person who requested credentials for @{params("applicationName")} if you think there has been a mistake or you do not want to verify.
+The link expires in 10 working days. After that, you may need to request production access again.
 
 From HMRC Developer Hub
 

--- a/it/uk/gov/hmrc/hmrcemailrenderer/TemplatePrioritiesISpec.scala
+++ b/it/uk/gov/hmrc/hmrcemailrenderer/TemplatePrioritiesISpec.scala
@@ -154,7 +154,8 @@ class TemplatePrioritiesISpec
         Map(
           "applicationName"           -> "applicationName",
           "developerHubLink"          -> "/developerHubLink",
-          "responsibleIndividualName" -> "responsibleIndividualName"
+          "responsibleIndividualName" -> "responsibleIndividualName",
+          "requesterName"             -> "requesterName"
         )),
       ("apiDeveloperEmailVerification", Map("verificationLink" -> "/abc", "recipientName_forename" -> "Ms Jane Doe")),
       ("apiDeveloperChangedPasswordConfirmation", Map[String, String]()),

--- a/it/uk/gov/hmrc/hmrcemailrenderer/TemplatePrioritiesISpec.scala
+++ b/it/uk/gov/hmrc/hmrcemailrenderer/TemplatePrioritiesISpec.scala
@@ -157,13 +157,6 @@ class TemplatePrioritiesISpec
           "responsibleIndividualName" -> "responsibleIndividualName",
           "requesterName"             -> "requesterName"
         )),
-      (
-        "apiResponsibleIndividualReminderToAdmin",
-        Map(
-          "applicationName"           -> "applicationName",
-          "responsibleIndividualName" -> "responsibleIndividualName",
-          "requesterName"             -> "requesterName"
-        )),
       ("apiDeveloperEmailVerification", Map("verificationLink" -> "/abc", "recipientName_forename" -> "Ms Jane Doe")),
       ("apiDeveloperChangedPasswordConfirmation", Map[String, String]()),
       ("apiDeveloperPasswordReset", Map("resetPasswordLink" -> "/reset")),

--- a/it/uk/gov/hmrc/hmrcemailrenderer/TemplatePrioritiesISpec.scala
+++ b/it/uk/gov/hmrc/hmrcemailrenderer/TemplatePrioritiesISpec.scala
@@ -157,6 +157,13 @@ class TemplatePrioritiesISpec
           "responsibleIndividualName" -> "responsibleIndividualName",
           "requesterName"             -> "requesterName"
         )),
+      (
+        "apiResponsibleIndividualReminderToAdmin",
+        Map(
+          "applicationName"           -> "applicationName",
+          "responsibleIndividualName" -> "responsibleIndividualName",
+          "requesterName"             -> "requesterName"
+        )),
       ("apiDeveloperEmailVerification", Map("verificationLink" -> "/abc", "recipientName_forename" -> "Ms Jane Doe")),
       ("apiDeveloperChangedPasswordConfirmation", Map[String, String]()),
       ("apiDeveloperPasswordReset", Map("resetPasswordLink" -> "/reset")),

--- a/it/uk/gov/hmrc/hmrcemailrenderer/TemplatePrioritiesISpec.scala
+++ b/it/uk/gov/hmrc/hmrcemailrenderer/TemplatePrioritiesISpec.scala
@@ -157,6 +157,13 @@ class TemplatePrioritiesISpec
           "responsibleIndividualName" -> "responsibleIndividualName",
           "requesterName"             -> "requesterName"
         )),
+      (
+        "apiResponsibleIndividualDeclined",
+        Map(
+          "applicationName"           -> "applicationName",
+          "responsibleIndividualName" -> "responsibleIndividualName",
+          "requesterName"             -> "requesterName"
+        )),
       ("apiDeveloperEmailVerification", Map("verificationLink" -> "/abc", "recipientName_forename" -> "Ms Jane Doe")),
       ("apiDeveloperChangedPasswordConfirmation", Map[String, String]()),
       ("apiDeveloperPasswordReset", Map("resetPasswordLink" -> "/reset")),

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
@@ -170,6 +170,7 @@ class TemplateLocatorSpec extends AnyWordSpecLike with should.Matchers with Opti
         "apiRemovedClientSecretNotification",
         "apiApplicationToBeDeletedNotification",
         "apiVerifyResponsibleIndividual",
+        "apiResponsibleIndividualReminderToAdmin",
         "changeOfEmailAddress",
         "changeOfEmailAddress_cy",
         "verifyEmailAddress",

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
@@ -171,6 +171,7 @@ class TemplateLocatorSpec extends AnyWordSpecLike with should.Matchers with Opti
         "apiApplicationToBeDeletedNotification",
         "apiVerifyResponsibleIndividual",
         "apiResponsibleIndividualReminderToAdmin",
+        "apiResponsibleIndividualDidNotVerify",
         "apiResponsibleIndividualDeclined",
         "changeOfEmailAddress",
         "changeOfEmailAddress_cy",

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
@@ -171,6 +171,7 @@ class TemplateLocatorSpec extends AnyWordSpecLike with should.Matchers with Opti
         "apiApplicationToBeDeletedNotification",
         "apiVerifyResponsibleIndividual",
         "apiResponsibleIndividualReminderToAdmin",
+        "apiResponsibleIndividualDeclined",
         "changeOfEmailAddress",
         "changeOfEmailAddress_cy",
         "verifyEmailAddress",

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplatesSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplatesSpec.scala
@@ -110,9 +110,14 @@ class ApiTemplatesSpec extends WordSpecLike with Matchers with OptionValues with
         expectedPriority = MessagePriority.Standard)
 
       validateTemplate(
-        templateId = "apiResponsibleIndividualDeclined",
+        templateId = "apiResponsibleIndividualDidNotVerify",
         expectedSubject = "Production credentials request declined",
         expectedPriority = MessagePriority.Standard)
+
+      validateTemplate(
+        templateId = "apiResponsibleIndividualDeclined",
+        expectedSubject = "Important update about your production credentials request",
+        expectedPriority = MessagePriority.Urgent)
 
       validateTemplate(
         templateId = "ppnsCallbackUrlChangedNotification",

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplatesSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplatesSpec.scala
@@ -101,7 +101,13 @@ class ApiTemplatesSpec extends WordSpecLike with Matchers with OptionValues with
 
       validateTemplate(
         templateId = "apiVerifyResponsibleIndividual",
-        expectedSubject = "Responsible Individual Verification")
+        expectedSubject = "Responsible Individual Verification",
+        expectedPriority = MessagePriority.Urgent)
+
+      validateTemplate(
+        templateId = "apiResponsibleIndividualReminderToAdmin",
+        expectedSubject = "Update about your request for production credentials",
+        expectedPriority = MessagePriority.Standard)
 
       validateTemplate(
         templateId = "ppnsCallbackUrlChangedNotification",

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplatesSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplatesSpec.scala
@@ -101,7 +101,7 @@ class ApiTemplatesSpec extends WordSpecLike with Matchers with OptionValues with
 
       validateTemplate(
         templateId = "apiVerifyResponsibleIndividual",
-        expectedSubject = "Responsible Individual Verification",
+        expectedSubject = "Responsible individual verification",
         expectedPriority = MessagePriority.Urgent)
 
       validateTemplate(

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplatesSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplatesSpec.scala
@@ -107,7 +107,8 @@ class ApiTemplatesSpec extends WordSpecLike with Matchers with OptionValues with
       validateTemplate(
         templateId = "apiResponsibleIndividualReminderToAdmin",
         expectedSubject = "Update about your request for production credentials",
-        expectedPriority = MessagePriority.Standard)
+        expectedPriority = MessagePriority.Standard
+      )
 
       validateTemplate(
         templateId = "apiResponsibleIndividualDidNotVerify",
@@ -117,7 +118,8 @@ class ApiTemplatesSpec extends WordSpecLike with Matchers with OptionValues with
       validateTemplate(
         templateId = "apiResponsibleIndividualDeclined",
         expectedSubject = "Important update about your production credentials request",
-        expectedPriority = MessagePriority.Urgent)
+        expectedPriority = MessagePriority.Urgent
+      )
 
       validateTemplate(
         templateId = "ppnsCallbackUrlChangedNotification",

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplatesSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplatesSpec.scala
@@ -110,6 +110,11 @@ class ApiTemplatesSpec extends WordSpecLike with Matchers with OptionValues with
         expectedPriority = MessagePriority.Standard)
 
       validateTemplate(
+        templateId = "apiResponsibleIndividualDeclined",
+        expectedSubject = "Production credentials request declined",
+        expectedPriority = MessagePriority.Standard)
+
+      validateTemplate(
         templateId = "ppnsCallbackUrlChangedNotification",
         expectedSubject = "Changes made to Callback URL",
         expectedPriority = MessagePriority.Urgent)


### PR DESCRIPTION
Update existing template apiVerifyResponsibleIndividual  with new content and add new templates related to responsible individual declining, failing to accept or requiring a reminder.