### PR TITLE
APIS-6014 Add new templates for production credential request expiry.

### DIFF
--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -218,6 +218,12 @@ object TemplateParams {
       "timeSinceLastUse"        -> "11 months",
       "dateOfScheduledDeletion" -> "1 April 2025"
     ),
+    "apiProductionCredentialsRequestExpired" -> Map(
+      "applicationName" -> "Test Application"
+    ),
+    "apiProductionCredentialsRequestExpiryWarning" -> Map(
+      "applicationName" -> "Test Application"
+    ),
     "apiVerifyResponsibleIndividual" -> Map(
       "developerHubLink"          -> exampleLinkWithRandomId,
       "applicationName"           -> "Test Application",

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplates.scala
@@ -202,6 +202,24 @@ object ApiTemplates {
       priority = Some(MessagePriority.Standard)
     ),
     MessageTemplate.createWithDynamicFromAddress(
+      templateId = "apiProductionCredentialsRequestExpired",
+      fromAddress = extractFromAddress,
+      service = ApiDeveloperHub,
+      subject = "Production credentials request deleted",
+      plainTemplate = txt.apiProductionCredentialsRequestExpired.f,
+      htmlTemplate = html.apiProductionCredentialsRequestExpired.f,
+      priority = Some(MessagePriority.Standard)
+    ),
+    MessageTemplate.createWithDynamicFromAddress(
+      templateId = "apiProductionCredentialsRequestExpiryWarning",
+      fromAddress = extractFromAddress,
+      service = ApiDeveloperHub,
+      subject = "About your request for production credentials",
+      plainTemplate = txt.apiProductionCredentialsRequestExpiryWarning.f,
+      htmlTemplate = html.apiProductionCredentialsRequestExpiryWarning.f,
+      priority = Some(MessagePriority.Standard)
+    ),
+    MessageTemplate.createWithDynamicFromAddress(
       templateId = "ppnsCallbackUrlChangedNotification",
       fromAddress = extractFromAddress,
       service = ApiDeveloperHub,

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiProductionCredentialsRequestExpired.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiProductionCredentialsRequestExpired.scala.html
@@ -17,6 +17,6 @@
 @(params: Map[String, Any])
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Your production credentials request is deleted") {
 <p style="margin: 0 0 30px; font-size: 19px;">Because you have not finished getting production credentials for @{params("applicationName")} in 6 months, we have deleted your progress.</p>
-<p style="margin: 0 0 10px; font-size: 19px;">You can request production credentials again at any time.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">You can request production credentials again at any time.</p>
 <p style="margin: 0 0 30px; font-size: 19px;">From HMRC Developer Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiProductionCredentialsRequestExpired.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiProductionCredentialsRequestExpired.scala.html
@@ -1,0 +1,22 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(params: Map[String, Any])
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Your production credentials request is deleted") {
+<p style="margin: 0 0 30px; font-size: 19px;">Because you have not finished getting production credentials for @{params("applicationName")} in 6 months, we have deleted your progress.</p>
+<p style="margin: 0 0 10px; font-size: 19px;">You can request production credentials again at any time.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">From HMRC Developer Hub</p>
+}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiProductionCredentialsRequestExpired.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiProductionCredentialsRequestExpired.scala.html
@@ -15,8 +15,8 @@
  *@
 
 @(params: Map[String, Any])
-@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Your production credentials request is deleted") {
-<p style="margin: 0 0 30px; font-size: 19px;">Because you have not finished getting production credentials for @{params("applicationName")} in 6 months, we have deleted your progress.</p>
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "We have deleted your request for production credentials") {
+<p style="margin: 0 0 30px; font-size: 19px;">We have deleted your progress because you have not finished getting production credentials for @{params("applicationName")} in 6 months.</p>
 <p style="margin: 0 0 30px; font-size: 19px;">You can request production credentials again at any time.</p>
 <p style="margin: 0 0 30px; font-size: 19px;">From HMRC Developer Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiProductionCredentialsRequestExpired.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiProductionCredentialsRequestExpired.scala.txt
@@ -1,6 +1,6 @@
-@(params: Map[String, Any])Your production credentials request is deleted
+@(params: Map[String, Any])We have deleted your request for production credentials
 
-Because you have not finished getting production credentials for @{params("applicationName")} in 6 months, we have deleted your progress.  
+We have deleted your progress because you have not finished getting production credentials for @{params("applicationName")} in 6 months.  
 
 You can request production credentials again at any time.
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiProductionCredentialsRequestExpired.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiProductionCredentialsRequestExpired.scala.txt
@@ -1,0 +1,9 @@
+@(params: Map[String, Any])Your production credentials request is deleted
+
+Because you have not finished getting production credentials for @{params("applicationName")} in 6 months, we have deleted your progress.  
+
+You can request production credentials again at any time.
+
+From HMRC Developer Hub
+
+@{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer()}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiProductionCredentialsRequestExpiryWarning.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiProductionCredentialsRequestExpiryWarning.scala.html
@@ -17,6 +17,5 @@
 @(params: Map[String, Any])
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Your request for production credentials") {
 <p style="margin: 0 0 30px; font-size: 19px;">You have 30 days to complete your request for production credentials for @{params("applicationName")}. After that, your progress is deleted, and you will need to start again.</p>
-<p style="margin: 0 0 30px; font-size: 19px;">Speak to the software developer support team if you need help at sdsteam@@hmrc.gov.uk.</p>
 <p style="margin: 0 0 30px; font-size: 19px;">From HMRC Developer Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiProductionCredentialsRequestExpiryWarning.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiProductionCredentialsRequestExpiryWarning.scala.html
@@ -17,6 +17,6 @@
 @(params: Map[String, Any])
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Your request for production credentials") {
 <p style="margin: 0 0 30px; font-size: 19px;">You have 30 days to complete your request for production credentials for @{params("applicationName")}. After that, your progress is deleted, and you will need to start again.</p>
-<p style="margin: 0 0 10px; font-size: 19px;">Speak to the software developer support team if you need help at sdsteam@@hmrc.gov.uk.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">Speak to the software developer support team if you need help at sdsteam@@hmrc.gov.uk.</p>
 <p style="margin: 0 0 30px; font-size: 19px;">From HMRC Developer Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiProductionCredentialsRequestExpiryWarning.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiProductionCredentialsRequestExpiryWarning.scala.html
@@ -1,0 +1,22 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(params: Map[String, Any])
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Your request for production credentials") {
+<p style="margin: 0 0 30px; font-size: 19px;">You have 30 days to complete your request for production credentials for @{params("applicationName")}. After that, your progress is deleted, and you will need to start again.</p>
+<p style="margin: 0 0 10px; font-size: 19px;">Speak to the software developer support team if you need help at sdsteam@@hmrc.gov.uk.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">From HMRC Developer Hub</p>
+}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiProductionCredentialsRequestExpiryWarning.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiProductionCredentialsRequestExpiryWarning.scala.txt
@@ -2,8 +2,6 @@
 
 You have 30 days to complete your request for production credentials for @{params("applicationName")}. After that, your progress is deleted, and you will need to start again.
 
-Speak to the software developer support team if you need help at sdsteam@@hmrc.gov.uk.
-
 From HMRC Developer Hub
 
 @{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer()}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiProductionCredentialsRequestExpiryWarning.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/api/apiProductionCredentialsRequestExpiryWarning.scala.txt
@@ -1,0 +1,9 @@
+@(params: Map[String, Any])Your request for production credentials
+
+You have 30 days to complete your request for production credentials for @{params("applicationName")}. After that, your progress is deleted, and you will need to start again.
+
+Speak to the software developer support team if you need help at sdsteam@@hmrc.gov.uk.
+
+From HMRC Developer Hub
+
+@{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer()}

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
@@ -175,6 +175,8 @@ class TemplateLocatorSpec extends AnyWordSpecLike with should.Matchers with Opti
         "apiAddedClientSecretNotification",
         "apiRemovedClientSecretNotification",
         "apiApplicationToBeDeletedNotification",
+        "apiProductionCredentialsRequestExpired",
+        "apiProductionCredentialsRequestExpiryWarning",
         "apiVerifyResponsibleIndividual",
         "apiVerifyResponsibleIndividualUpdate",
         "apiResponsibleIndividualReminderToAdmin",

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplatesSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/api/ApiTemplatesSpec.scala
@@ -100,6 +100,18 @@ class ApiTemplatesSpec extends WordSpecLike with Matchers with OptionValues with
         expectedPriority = MessagePriority.Standard)
 
       validateTemplate(
+        templateId = "apiProductionCredentialsRequestExpired",
+        expectedSubject = "Production credentials request deleted",
+        expectedPriority = MessagePriority.Standard
+      )
+
+      validateTemplate(
+        templateId = "apiProductionCredentialsRequestExpiryWarning",
+        expectedSubject = "About your request for production credentials",
+        expectedPriority = MessagePriority.Standard
+      )
+
+      validateTemplate(
         templateId = "apiVerifyResponsibleIndividual",
         expectedSubject = "Responsible individual verification",
         expectedPriority = MessagePriority.Urgent)


### PR DESCRIPTION
Two new API Platform email templates which are used to warn of the expiry of production credential requests on the Developer Hub.   These are sent to all adminstrators of an application:

- after 5 months to warn that their request is about to expire
- after 6 months to say that the request has expired and has been deleted