### PR TITLE
SAR-10986 | Update footer text to use bullet points and welsh translations for VRS templates

### DIFF
--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received_cy.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received_cy.scala.txt
@@ -12,4 +12,4 @@ Dylech aros nes i’ch cofrestriad TAW gael ei gadarnhau cyn:
 
 Oddi wrth Dîm TAW CThEM
 
-@{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer()}
+@{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer_cy()}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received_email_cy.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received_email_cy.scala.txt
@@ -16,4 +16,4 @@ Dylech aros nes i’ch cofrestriad TAW gael ei gadarnhau cyn:
 
 Oddi wrth Dîm TAW CThEM
 
-@{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer()}
+@{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer_cy()}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received_post_cy.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received_post_cy.scala.txt
@@ -16,4 +16,4 @@ Dylech aros nes i’ch cofrestriad TAW gael ei gadarnhau cyn:
 
 Oddi wrth Dîm TAW CThEM
 
-@{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer()}
+@{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer_cy()}


### PR DESCRIPTION
- Ran the tests to verify coverage
- Verified the changes by running the test routes and checked on both html & text content to make sure we have the required changes for
  
  - VRS welsh templates to use correct welsh footer (`template_footer_cy`)