### PR TITLE
SAR-11162 | Update SLA to 40 days and remove vatreg email templates

### DIFF
--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received.scala.html
@@ -21,7 +21,7 @@
 
     <p style="margin: 0 0 30px; font-size: 19px; font-weight: 700;">Reference number: @params("ref")</p>
 
-    <p style="margin: 0 0 30px; font-size: 19px;">We’ve received your application and we will write to you with a decision in about 40 days.</p>
+    <p style="margin: 0 0 30px; font-size: 19px;">We’ve received your application and we will write to you with a decision within 40 working days.</p>
 
     <p style="margin: 0 0 30px; font-size: 19px;">You should wait until we confirm your VAT registration before you get software to follow the rules for ‘Making Tax Digital for VAT’.</p>
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received.scala.txt
@@ -4,7 +4,7 @@ Dear @params("name")
 
 Reference number: @params("ref")
 
-We’ve received your application and we will write to you with a decision in about 40 days.
+We’ve received your application and we will write to you with a decision within 40 working days.
 
 You should wait until we confirm your VAT registration before you get software to follow the rules for ‘Making Tax Digital for VAT’.
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received_cy.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received_cy.scala.html
@@ -21,7 +21,7 @@
 
     <p style="margin: 0 0 30px; font-size: 19px; font-weight: 700;">Cyfeirnod: @params("ref")</p>
 
-    <p style="margin: 0 0 30px; font-size: 19px;">Mae’ch cais wedi dod i law a byddwn yn ysgrifennu atoch gyda phenderfyniad mewn tua 40 diwrnod.</p>
+    <p style="margin: 0 0 30px; font-size: 19px;">Mae’ch cais wedi dod i law a byddwn yn ysgrifennu atoch gyda phenderfyniad cyn pen 40 diwrnod gwaith.</p>
 
     <p style="margin: 0 0 30px; font-size: 19px;">Dylech aros nes i ni gadarnhau eich cofrestriad TAW cyn i chi gael meddalwedd i ddilyn rheolau’r cynllun ‘Troi Treth yn Ddigidol ar gyfer TAW’.</p>
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received_cy.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received_cy.scala.txt
@@ -4,7 +4,7 @@ Annwyl @params("name")
 
 Cyfeirnod: @params("ref")
 
-Mae’ch cais wedi dod i law a byddwn yn ysgrifennu atoch gyda phenderfyniad mewn tua 40 diwrnod.
+Mae’ch cais wedi dod i law a byddwn yn ysgrifennu atoch gyda phenderfyniad cyn pen 40 diwrnod gwaith.
 
 Dylech aros nes i ni gadarnhau eich cofrestriad TAW cyn i chi gael meddalwedd i ddilyn rheolau’r cynllun ‘Troi Treth yn Ddigidol ar gyfer TAW’.
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received_post.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received_post.scala.html
@@ -26,7 +26,7 @@
     <h2 style="margin: 0 0 30px; font-size: 19px;">What happens next</h2>
 
     <ol>
-        <li style="margin: 0 0 0px; font-size: 19px;">After we receive copies of your documents, we’ll write to you with a decision on your application in about 40 days.</li>
+        <li style="margin: 0 0 0px; font-size: 19px;">After we receive copies of your documents, we’ll write to you with a decision on your application within 40 working days.</li>
         <li style="margin: 0 0 30px; font-size: 19px;">You should wait until we confirm your VAT registration before you get software to follow the rules for ‘Making Tax Digital for VAT’.</li>
     </ol>
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received_post.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received_post.scala.txt
@@ -8,7 +8,7 @@ So we can process your application, you need to post us a cover letter and copie
 
 What happens next
 
-After we receive copies of your documents, we’ll write to you with a decision on your application in about 40 days.
+After we receive copies of your documents, we’ll write to you with a decision on your application within 40 working days.
 You should wait until we confirm your VAT registration before you get software to follow the rules for ‘Making Tax Digital for VAT’.
 
 You cannot include VAT on your invoices until you get your VAT number. However, you can increase your prices to account for the VAT you’ll need to pay HMRC.

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received_post_cy.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received_post_cy.scala.html
@@ -29,7 +29,7 @@
     <h2 style="margin: 0 0 30px; font-size: 19px;">Yr hyn sy’n digwydd nesaf</h2>
 
     <ol>
-        <li style="margin: 0 0 0px; font-size: 19px;">Ar ôl i ni gael copïau o’ch dogfennau, byddwn yn ysgrifennu atoch gyda phenderfyniad ar eich cais mewn tua 40 diwrnod.</li>
+        <li style="margin: 0 0 0px; font-size: 19px;">Ar ôl i ni gael copïau o’ch dogfennau, byddwn yn ysgrifennu atoch gyda phenderfyniad ar eich cais cyn pen 40 diwrnod gwaith.</li>
         <li style="margin: 0 0 30px; font-size: 19px;">Dylech aros nes i ni gadarnhau eich cofrestriad TAW cyn i chi gael meddalwedd i ddilyn rheolau’r cynllun ‘Troi Treth yn Ddigidol ar gyfer TAW’.</li>
     </ol>
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received_post_cy.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/mtdfb/vatreg/registration_received_post_cy.scala.txt
@@ -8,7 +8,7 @@ Er mwyn i ni allu ei brosesu, mae angen i chi bostio llythyr eglurhaol atom yngh
 
 Yr hyn sy’n digwydd nesaf
 
-Ar ôl i ni gael copïau o’ch dogfennau, byddwn yn ysgrifennu atoch gyda phenderfyniad ar eich cais mewn tua 40 diwrnod.
+Ar ôl i ni gael copïau o’ch dogfennau, byddwn yn ysgrifennu atoch gyda phenderfyniad ar eich cais cyn pen 40 diwrnod gwaith.
 
 Dylech aros nes i ni gadarnhau eich cofrestriad TAW cyn i chi gael meddalwedd i ddilyn rheolau’r cynllun ‘Troi Treth yn Ddigidol ar gyfer TAW’.
 


### PR DESCRIPTION
[SAR-11162](https://jira.tools.tax.service.gov.uk/browse/SAR-11162)

- Fix to SLA content in templates for VATReg templates