### PR TITLE
DAC6-3189: Update MDR file upload failed content

### DIFF
--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/mdr/MdrTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/mdr/MdrTemplates.scala
@@ -55,7 +55,7 @@ object MdrTemplates {
       templateId = "mdr_file_upload_unsuccessful",
       fromAddress = FromAddress.noReply("MDR@notifications.service.gov.uk"),
       service = MDR,
-      subject = "Your file has failed checks for MDR",
+      subject = "There is a problem with your file for MDR",
       plainTemplate = txt.mdrFileUploadUnsuccessful.f,
       htmlTemplate = html.mdrFileUploadUnsuccessful.f,
       priority = Some(MessagePriority.Urgent)

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/mdr/mdrFileUploadUnsuccessful.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/mdr/mdrFileUploadUnsuccessful.scala.html
@@ -15,15 +15,17 @@
  *@
 
 @(params: Map[String, Any])
-@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "File failed checks for the MDR service") {
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "There is a problem with your file for MDR") {
 
 <p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 30px 0;">Dear @{params("contactName")}</p>
 
-<p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 30px 0;">Your file failed the Mandatory Disclosure Rules checks at @{params("dateAndTime")}.</p>
+<p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 30px 0;">There is a problem with the file you tried to send at @{params("dateAndTime")} for the Mandatory Disclosure Rules (MDR) service.</p>
+
+<p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 30px 0;">You must send another version. Late reports may result in a penalty.</p>
+
+<p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 30px 0;">You can check any errors or problems in the MDR service and upload an updated XML file.</p>
 
 <p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 30px 0;">For reference, the File ID (MessageRefId) is: @{params("messageRefId")}</p>
-
-<p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 30px 0;">You can check the errors in the MDR service and upload an updated XML file.</p>
 
 <p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 30px 0;">For security reasons, we have not included a link to the MDR service in this email.</p>
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/mdr/mdrFileUploadUnsuccessful.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/mdr/mdrFileUploadUnsuccessful.scala.txt
@@ -14,7 +14,6 @@ For reference, the File ID (MessageRefId) is: @{params("messageRefId")}
 For security reasons, we have not included a link to the MDR service in this email.
 
 If you need help
-
 Email aeoi.enquiries@@hmrc.gov.uk for help with this service.
 
 For more information on MDR, you can visit GOV.UK and search for ‘Mandatory Disclosure Rules’.

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/mdr/mdrFileUploadUnsuccessful.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/mdr/mdrFileUploadUnsuccessful.scala.txt
@@ -1,13 +1,15 @@
 @(params: Map[String, Any])
-File failed checks for the MDR service
+There is a problem with your file for MDR
 
 Dear @{params("contactName")}
 
-Your file failed the Mandatory Disclosure Rules checks at @{params("dateAndTime")}.
+There is a problem with the file you tried to send at @{params("dateAndTime")} for the Mandatory Disclosure Rules (MDR) service.
+
+You must send another version. Late reports may result in a penalty.
+
+You can check any errors or problems in the MDR service and upload an updated XML file.
 
 For reference, the File ID (MessageRefId) is: @{params("messageRefId")}
-
-You can check the errors in the MDR service and upload an updated XML file.
 
 For security reasons, we have not included a link to the MDR service in this email.
 


### PR DESCRIPTION
Screenshots of rendered previews below.

Apologies I couldn't get the logos to display - ASSETS_FRONTEND doesnt seem to exist anymore?

HTML:
![Screenshot 2024-04-24 at 15 38 57](https://github.com/hmrc/hmrc-email-renderer/assets/238270/a72e3cd7-85c7-47a1-9a0c-59dbf06a8421)

Text:
<img width="1051" alt="Screenshot 2024-04-26 at 11 46 51" src="https://github.com/hmrc/hmrc-email-renderer/assets/238270/5c742181-52fc-48c9-8d5c-791719fba853">