### PR TITLE
HIPP-1398: Change URL for The Integration Hub

### DIFF
--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/AddTeamMemberToApp.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/AddTeamMemberToApp.scala.html
@@ -17,6 +17,6 @@
 @(params: Map[String, Any])
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "You have been added to an application in The Integration Hub"){
  <p style="margin: 0 0 30px; font-size: 19px;">You have been added as a team member to @params("applicationname") within The Integration Hub, by @params("creatorusername").</p>
-<p style="margin: 0 0 30px; font-size: 19px;">To access the application, visit /api-hub on the MDTP admin network.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">To access the application, visit /integration-hub on the MDTP admin network.</p>
  <p style="margin: 0 0 30px; font-size: 19px;">From HMRC The Integration Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/AddTeamMemberToApp.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/AddTeamMemberToApp.scala.txt
@@ -1,4 +1,4 @@
 @(params: Map[String, Any])
 You have been added as a team member to @{params("applicationname")} within The Integration Hub, by @{params("creatorusername")}.
-To access the application, visit /api-hub on the MDTP admin network.
+To access the application, visit /integration-hub on the MDTP admin network.
 From HMRC The Integration Hub

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/AddTeamMemberToTeam.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/AddTeamMemberToTeam.scala.html
@@ -17,6 +17,6 @@
 @(params: Map[String, Any])
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "You have been added to a team in The Integration Hub"){
  <p style="margin: 0 0 30px; font-size: 19px;">You have been added as a team member to @params("teamname") within The Integration Hub.</p>
-<p style="margin: 0 0 30px; font-size: 19px;">To access the team, visit /api-hub on the MDTP admin network.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">To access the team, visit /integration-hub on the MDTP admin network.</p>
  <p style="margin: 0 0 30px; font-size: 19px;">From HMRC The Integration Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/AddTeamMemberToTeam.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/AddTeamMemberToTeam.scala.txt
@@ -1,4 +1,4 @@
 @(params: Map[String, Any])
 You have been added as a team member to @{params("teamname")} within The Integration Hub.
-To access the team, visit /api-hub on the MDTP admin network.
+To access the team, visit /integration-hub on the MDTP admin network.
 From HMRC The Integration Hub

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ApiOwnershipAdded.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ApiOwnershipAdded.scala.html
@@ -17,7 +17,7 @@
 @(params: Map[String, Any])
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "There has been a change of API ownership"){
 <p style="margin: 0 0 30px; font-size: 19px;">Your team @params("teamname") is the new owner of @params("apispecificationname").</p>
-<p style="margin: 0 0 30px; font-size: 19px;">To view this change, visit /api-hub on the MDTP admin network.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">To view this change, visit /integration-hub on the MDTP admin network.</p>
 <p style="margin: 0 0 30px; font-size: 19px;">If this is an error, please follow the Get Support link on the Hub.</p>
 <p style="margin: 0 0 30px; font-size: 19px;">From HMRC The Integration Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ApiOwnershipAdded.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ApiOwnershipAdded.scala.txt
@@ -1,5 +1,5 @@
 @(params: Map[String, Any])
 Your team @params("teamname") is the new owner of @params("apispecificationname").
-To view this change, visit /api-hub on the MDTP admin network.
+To view this change, visit /integration-hub on the MDTP admin network.
 If this is an error, please follow the Get Support link on the Hub.
 From HMRC The Integration Hub

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ApiOwnershipRemoved.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ApiOwnershipRemoved.scala.html
@@ -17,7 +17,7 @@
 @(params: Map[String, Any])
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "There has been a change of API ownership"){
 <p style="margin: 0 0 30px; font-size: 19px;">Your team @params("teamname") is no longer the owner of @params("apispecificationname"). The team @params("otherteamname") is now the new owner of this API.</p>
-<p style="margin: 0 0 30px; font-size: 19px;">To view this change, visit /api-hub on the MDTP admin network.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">To view this change, visit /integration-hub on the MDTP admin network.</p>
 <p style="margin: 0 0 30px; font-size: 19px;">If this is an error, please follow the Get Support link on the Hub.</p>
 <p style="margin: 0 0 30px; font-size: 19px;">From HMRC The Integration Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ApiOwnershipRemoved.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ApiOwnershipRemoved.scala.txt
@@ -1,5 +1,5 @@
 @(params: Map[String, Any])
 Your team @params("teamname") is no longer the owner of @params("apispecificationname"). The team @params("otherteamname") is now the new owner of this API.
-To view this change, visit /api-hub on the MDTP admin network.
+To view this change, visit /integration-hub on the MDTP admin network.
 If this is an error, please follow the Get Support link on the Hub.
 From HMRC The Integration Hub

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ApplicationCreated.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ApplicationCreated.scala.html
@@ -17,6 +17,6 @@
 @(params: Map[String, Any])
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "You have created an application in The Integration Hub"){
 <p style="margin: 0 0 30px; font-size: 19px;">You have created @params("applicationname") in The Integration Hub.</p>
-<p style="margin: 0 0 30px; font-size: 19px;">To access the application, visit /api-hub on the MDTP admin network.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">To access the application, visit /integration-hub on the MDTP admin network.</p>
 <p style="margin: 0 0 30px; font-size: 19px;">From HMRC The Integration Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ApplicationCreated.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ApplicationCreated.scala.txt
@@ -1,4 +1,4 @@
 @(params: Map[String, Any])
 You have created @{params("applicationname")} in The Integration Hub.
-To access the application, visit /api-hub on the MDTP admin network.
+To access the application, visit /integration-hub on the MDTP admin network.
 From HMRC The Integration Hub

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/NewProductionAccessRequest.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/NewProductionAccessRequest.scala.html
@@ -17,6 +17,6 @@
 @(params: Map[String, Any])
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "A new production access request has been submitted for your review"){
  <p style="margin: 0 0 30px; font-size: 19px;">A request was submitted for the application @params("applicationname") to access the @params("apispecificationname") in the production environment.</p>
- <p style="margin: 0 0 30px; font-size: 19px;">To access the application, visit /api-hub on the MDTP admin network.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">To access the application, visit /integration-hub on the MDTP admin network.</p>
  <p style="margin: 0 0 30px; font-size: 19px;">From HMRC The Integration Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/NewProductionAccessRequest.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/NewProductionAccessRequest.scala.txt
@@ -1,4 +1,4 @@
 @(params: Map[String, Any])
 A request was submitted for the application @{params("applicationname")} to access the @{params("apispecificationname")} in the production environment.
-To access the application, visit /api-hub on the MDTP admin network.
+To access the application, visit /integration-hub on the MDTP admin network.
 From HMRC The Integration Hub

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ProductionAccessRequestApproved.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ProductionAccessRequestApproved.scala.html
@@ -17,7 +17,7 @@
 @(params: Map[String, Any])
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Your production access request has been approved"){
  <p style="margin: 0 0 30px; font-size: 19px;">A request was submitted for your application @params("applicationname") to access the @params("apispecificationname") in the production environment. This request has now been approved.</p>
- <p style="margin: 0 0 30px; font-size: 19px;">To access the application, visit /api-hub on the MDTP admin network.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">To access the application, visit /integration-hub on the MDTP admin network.</p>
  <p style="margin: 0 0 30px; font-size: 19px;">Please note that you may still need to generate production credentials if you have not done so already. Find more details on the 'Environments and credentials' page of your application.</p>
  <p style="margin: 0 0 30px; font-size: 19px;">From HMRC The Integration Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ProductionAccessRequestApproved.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ProductionAccessRequestApproved.scala.txt
@@ -1,5 +1,5 @@
 @(params: Map[String, Any])
 A request was submitted for your application @{params("applicationname")} to access the @{params("apispecificationname")} in the production environment. This request has now been approved.
-To access the application, visit /api-hub on the MDTP admin network.
+To access the application, visit /integration-hub on the MDTP admin network.
 Please note that you may still need to generate production credentials if you have not done so already. Find more details on the 'Environments and credentials' page of your application.
 From HMRC The Integration Hub

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ProductionAccessRequestRejected.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ProductionAccessRequestRejected.scala.html
@@ -17,6 +17,6 @@
 @(params: Map[String, Any])
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Your production access request has been rejected"){
  <p style="margin: 0 0 30px; font-size: 19px;">A request was submitted for your application @params("applicationname") to access the @params("apispecificationname") in the production environment. This request has been rejected.</p>
- <p style="margin: 0 0 30px; font-size: 19px;">To access the application, visit /api-hub on the MDTP admin network.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">To access the application, visit /integration-hub on the MDTP admin network.</p>
  <p style="margin: 0 0 30px; font-size: 19px;">From HMRC The Integration Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ProductionAccessRequestRejected.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ProductionAccessRequestRejected.scala.txt
@@ -1,4 +1,4 @@
 @(params: Map[String, Any])
 A request was submitted for your application @{params("applicationname")} to access the @{params("apispecificationname")} in the production environment. This request has been rejected.
-To access the application, visit /api-hub on the MDTP admin network.
+To access the application, visit /integration-hub on the MDTP admin network.
 From HMRC The Integration Hub

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ProductionAccessRequestSubmitted.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ProductionAccessRequestSubmitted.scala.html
@@ -17,7 +17,7 @@
 @(params: Map[String, Any])
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "Your production access request was successfully submitted"){
  <p style="margin: 0 0 30px; font-size: 19px;">Your request for your application @params("applicationname") to access the @params("apispecificationname") in the production environment has been successfully submitted for review.</p>
- <p style="margin: 0 0 30px; font-size: 19px;">To access the application, visit /api-hub on the MDTP admin network.</p>
+ <p style="margin: 0 0 30px; font-size: 19px;">To access the application, visit /integration-hub on the MDTP admin network.</p>
  <p style="margin: 0 0 30px; font-size: 19px;">Please note that if you are granted production access to this API, you may still need to generate production credentials if you have not done so already. Find more details on the 'Environments and credentials' page of your application.</p>
  <p style="margin: 0 0 30px; font-size: 19px;">From HMRC The Integration Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ProductionAccessRequestSubmitted.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/ProductionAccessRequestSubmitted.scala.txt
@@ -1,5 +1,5 @@
 @(params: Map[String, Any])
 Your request for your application @{params("applicationname")} to access the @{params("apispecificationname")} in the production environment has been successfully submitted for review.
-To access the application, visit /api-hub on the MDTP admin network.
+To access the application, visit /integration-hub on the MDTP admin network.
 Please note that if you are granted production access to this API, you may still need to generate production credentials if you have not done so already. Find more details on the 'Environments and credentials' page of your application.
 From HMRC The Integration Hub

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/RemoveMemberFromTeam.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/RemoveMemberFromTeam.scala.html
@@ -17,6 +17,6 @@
 @(params: Map[String, Any])@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "You have been removed from a team on the Integration Hub") {
     <p style="margin: 0 0 30px; font-size: 19px;">You have been removed as a team member from @params("teamname") within the Integration Hub.</p>
     <p style="margin: 0 0 30px; font-size: 19px;">You will no longer have access to @params("teamname").</p>
-    <p style="margin: 0 0 30px; font-size: 19px;">To access The Integration Hub, visit /api-hub on the MDTP admin network.</p>
+    <p style="margin: 0 0 30px; font-size: 19px;">To access The Integration Hub, visit /integration-hub on the MDTP admin network.</p>
     <p style="margin: 0 0 30px; font-size: 19px;">From HMRC The Integration Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/RemoveMemberFromTeam.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/RemoveMemberFromTeam.scala.txt
@@ -1,5 +1,5 @@
 @(params: Map[String, Any])
 You have been removed as a team member from @{params("teamname")} within the Integration Hub.
 You will no longer have access to @{params("teamname")}.
-To access The Integration Hub, visit /api-hub on the MDTP admin network.
+To access The Integration Hub, visit /integration-hub on the MDTP admin network.
 From HMRC The Integration Hub

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/RemoveTeamMember.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/RemoveTeamMember.scala.html
@@ -18,6 +18,6 @@
     <p style="margin: 0 0 30px; font-size: 19px;">You have been removed from @params("applicationname") within The Integration Hub, by @params("creatorusername").</p>
     <p style="margin: 0 0 30px; font-size: 19px;">You will no longer have access to @params("applicationname").</p>
     <p style="margin: 0 0 30px; font-size: 19px;">If you need to access this application, you will need to be added as a team member again.</p>
-    <p style="margin: 0 0 30px; font-size: 19px;">To access The Integration Hub, visit /api-hub on the MDTP admin network.</p>
+    <p style="margin: 0 0 30px; font-size: 19px;">To access The Integration Hub, visit /integration-hub on the MDTP admin network.</p>
     <p style="margin: 0 0 30px; font-size: 19px;">From HMRC The Integration Hub</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/RemoveTeamMember.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/hipp/RemoveTeamMember.scala.txt
@@ -1,4 +1,4 @@
 @(params: Map[String, Any])
 You have been removed from @{params("applicationname")} within The Integration Hub, by @{params("creatorusername")}.
-You will no longer have access to @{params("applicationname")}. If you need to access this application, you will need to be added as a team member again. To access The Integration Hub, visit /api-hub on the MDTP admin network.
+You will no longer have access to @{params("applicationname")}. If you need to access this application, you will need to be added as a team member again. To access The Integration Hub, visit /integration-hub on the MDTP admin network.
 From HMRC The Integration Hub


### PR DESCRIPTION
Change the following text in multiple templates to support rebranding of The API Hub to The Integration Hub:

visit /api-hub on the MDTP admin network
to
visit /integration-hub on the MDTP admin network

https://jira.tools.tax.service.gov.uk/browse/HIPP-1398
