### PR TITLE
[MMCA- 5190] - Add templates for primary email address change for CDS Financials

### DIFF
--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -22,6 +22,7 @@ import preview.examples.GG
 import uk.gov.hmrc.hmrcemailrenderer.templates.cf.ContactFormsTemplates.{ cf_enquiry_confirmation, cf_enquiry_confirmation_cy }
 import uk.gov.hmrc.hmrcemailrenderer.templates.rald.RaldTemplates.{ rald_connection_removed, rald_connection_removed_cy }
 import uk.gov.hmrc.hmrcemailrenderer.templates.tctr.TctrTemplates._
+import uk.gov.hmrc.hmrcemailrenderer.templates.customsfinancials.CustomsFinancialsTemplates.customsFinancialsChangeEmailAddress
 
 import java.util.{ Base64, UUID }
 
@@ -3820,6 +3821,9 @@ object TemplateParams3 {
     ),
     "customs_financials_requested_cash_account_transactions" -> Map(
       "recipientName_FullName" -> "ABC ltd"
+    ),
+    customsFinancialsChangeEmailAddress -> Map(
+      "emailAddress" -> "tony@abcltd.com"
     ),
     "undertaking_admin_deadline_reminder" -> Map(
       "deadline" -> "23 November 2023"

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/customsfinancials/ChangeOfPrimaryEmailAddress.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/customsfinancials/ChangeOfPrimaryEmailAddress.scala.html
@@ -21,6 +21,6 @@
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.salutation(params)
 
 <p style="margin: 0 0 16px; font-size: 19px;">Your primary email address for Customs Declaration Service notifications has been changed.</p>
-<p style="margin: 0 0 16px 0; font-size: 19px;">You will no longer receive notifications to @params.get("emailAddress").</p>
+<p style="margin: 0 0 16px 0; font-size: 19px;">You will no longer receive notifications to @params("emailAddress").</p>
 <p style="margin: 0 0 40px 0; font-size: 19px;">From the Customs Declaration Service</p>
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/customsfinancials/ChangeOfPrimaryEmailAddress.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/customsfinancials/ChangeOfPrimaryEmailAddress.scala.html
@@ -1,0 +1,26 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(params: Map[String, Any])
+
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "You’ve changed your email address") {
+
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.salutation(params)
+
+<p style="margin: 0 0 16px; font-size: 19px;">Your primary email address for Customs Declaration Service notifications has been changed.</p>
+<p style="margin: 0 0 16px 0; font-size: 19px;">You will no longer receive notifications to @params.get("emailAddress").</p>
+<p style="margin: 0 0 40px 0; font-size: 19px;">From the Customs Declaration Service</p>
+}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/customsfinancials/ChangeOfPrimaryEmailAddress.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/customsfinancials/ChangeOfPrimaryEmailAddress.scala.txt
@@ -4,7 +4,7 @@
 
 Your primary email address for Customs Declaration Service notifications has been changed.
 
-You will no longer receive notifications to @params.get("emailAddress").
+You will no longer receive notifications to @params("emailAddress").
 
 From the Customs Declaration Service
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/customsfinancials/ChangeOfPrimaryEmailAddress.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/customsfinancials/ChangeOfPrimaryEmailAddress.scala.txt
@@ -1,0 +1,11 @@
+@(params: Map[String, Any])You’ve changed your email address
+
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.salutation(params)
+
+Your primary email address for Customs Declaration Service notifications has been changed.
+
+You will no longer receive notifications to @params.get("emailAddress").
+
+From the Customs Declaration Service
+
+@{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer()}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/customsfinancials/CustomsFinancialsTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/customsfinancials/CustomsFinancialsTemplates.scala
@@ -150,6 +150,15 @@ object CustomsFinancialsTemplates {
       plainTemplate = txt.requestedCashAccountTransactions.f,
       htmlTemplate = html.requestedCashAccountTransactions.f,
       priority = Some(MessagePriority.Standard)
+    ),
+    MessageTemplate.create(
+      templateId = "customs_financials_change_email",
+      fromAddress = govUkTeamAddress,
+      service = CustomsFinancials,
+      subject = "Primary email address change",
+      plainTemplate = txt.ChangeOfPrimaryEmailAddress.f,
+      htmlTemplate = html.ChangeOfPrimaryEmailAddress.f,
+      priority = Some(MessagePriority.Standard)
     )
   )
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/customsfinancials/CustomsFinancialsTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/customsfinancials/CustomsFinancialsTemplates.scala
@@ -152,7 +152,7 @@ object CustomsFinancialsTemplates {
       priority = Some(MessagePriority.Standard)
     ),
     MessageTemplate.create(
-      templateId = "customs_financials_change_email",
+      templateId = "customs_financials_change_email_address",
       fromAddress = govUkTeamAddress,
       service = CustomsFinancials,
       subject = "Primary email address change",

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/customsfinancials/CustomsFinancialsTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/customsfinancials/CustomsFinancialsTemplates.scala
@@ -21,7 +21,10 @@ import uk.gov.hmrc.hmrcemailrenderer.templates.ServiceIdentifier.CustomsFinancia
 import uk.gov.hmrc.hmrcemailrenderer.templates.FromAddress.govUkTeamAddress
 
 object CustomsFinancialsTemplates {
-  val templates = Seq(
+
+  val customsFinancialsChangeEmailAddress = "customs_financials_change_email_address"
+
+  val templates: Seq[MessageTemplate] = Seq(
     MessageTemplate.create(
       // TODO rename to customs_financials_new_duty_deferment_statement
       templateId = "customs_financials_new_statement_notification",
@@ -152,7 +155,7 @@ object CustomsFinancialsTemplates {
       priority = Some(MessagePriority.Standard)
     ),
     MessageTemplate.create(
-      templateId = "customs_financials_change_email_address",
+      templateId = customsFinancialsChangeEmailAddress,
       fromAddress = govUkTeamAddress,
       service = CustomsFinancials,
       subject = "Primary email address change",

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
@@ -388,6 +388,7 @@ class TemplateLocatorSpec extends AnyWordSpecLike with should.Matchers with Opti
         "customs_financials_requested_postponed_import_vat_statements_not_found",
         "customs_financials_requested_notification_adjustment_statements_not_found",
         "customs_financials_requested_cash_account_transactions",
+        "customs_financials_change_email",
         "customs_migrate_not_successful",
         "customs_migrate_successful",
         "customs_payment_required",

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
@@ -388,7 +388,7 @@ class TemplateLocatorSpec extends AnyWordSpecLike with should.Matchers with Opti
         "customs_financials_requested_postponed_import_vat_statements_not_found",
         "customs_financials_requested_notification_adjustment_statements_not_found",
         "customs_financials_requested_cash_account_transactions",
-        "customs_financials_change_email",
+        "customs_financials_change_email_address",
         "customs_migrate_not_successful",
         "customs_migrate_successful",
         "customs_payment_required",

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/customsFinancials/CustomsFinancialsSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/customsFinancials/CustomsFinancialsSpec.scala
@@ -122,7 +122,7 @@ class CustomsFinancialsSpec extends TemplateComparisonSpec with CommonParamsForS
     "include change primary email address content" in {
       val params = commonParameters ++ Map("emailAddress" -> "abc@test.com")
 
-      val (htmlContent, _) = generateContent("customs_financials_change_email", params)
+      val (htmlContent, _) = generateContent("customs_financials_change_email_address", params)
 
       htmlContent must include("You’ve changed your email address")
       htmlContent must include(
@@ -258,8 +258,8 @@ class CustomsFinancialsSpec extends TemplateComparisonSpec with CommonParamsForS
       )
     }
 
-    "have matching content in customs_financials_change_email" in {
-      compareContent("customs_financials_change_email", commonParameters)(customsFinancialsTemplate)
+    "have matching content in customs_financials_change_email_address" in {
+      compareContent("customs_financials_change_email_address", commonParameters)(customsFinancialsTemplate)
     }
   }
 

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/customsFinancials/CustomsFinancialsSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/customsFinancials/CustomsFinancialsSpec.scala
@@ -17,6 +17,9 @@
 package uk.gov.hmrc.hmrcemailrenderer.templates.customsFinancials
 
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import preview.TemplateParams
+import preview.TemplateParams2
+import uk.gov.hmrc.hmrcemailrenderer.templates.cf.ContactFormsTemplates.cf_enquiry_confirmation
 import uk.gov.hmrc.hmrcemailrenderer.templates.{ CommonParamsForSpec, TemplateComparisonSpec, customsfinancials }
 
 class CustomsFinancialsSpec extends TemplateComparisonSpec with CommonParamsForSpec with GuiceOneAppPerSuite {
@@ -120,6 +123,7 @@ class CustomsFinancialsSpec extends TemplateComparisonSpec with CommonParamsForS
     }
 
     "include change primary email address content" in {
+
       val params = commonParameters ++ Map("emailAddress" -> "abc@test.com")
 
       val (htmlContent, _) = generateContent("customs_financials_change_email_address", params)
@@ -259,7 +263,9 @@ class CustomsFinancialsSpec extends TemplateComparisonSpec with CommonParamsForS
     }
 
     "have matching content in customs_financials_change_email_address" in {
-      compareContent("customs_financials_change_email_address", commonParameters)(customsFinancialsTemplate)
+      val params = commonParameters ++ Map("emailAddress" -> "abc@test.com")
+
+      compareContent("customs_financials_change_email_address", params)(customsFinancialsTemplate)
     }
   }
 

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/customsFinancials/CustomsFinancialsSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/customsFinancials/CustomsFinancialsSpec.scala
@@ -118,6 +118,19 @@ class CustomsFinancialsSpec extends TemplateComparisonSpec with CommonParamsForS
       htmlContent must not include "The total Duty and VAT owed will be collected by direct debit on or after 15 June 2018."
       htmlContent must not include "If you owe over £20 million you must make a CHAPS payment to HMRC."
     }
+
+    "include change primary email address content" in {
+      val params = commonParameters ++ Map("emailAddress" -> "abc@test.com")
+
+      val (htmlContent, _) = generateContent("customs_financials_change_email", params)
+
+      htmlContent must include("You’ve changed your email address")
+      htmlContent must include(
+        "Your primary email address for Customs Declaration Service notifications has been changed."
+      )
+      htmlContent must include("You will no longer receive notifications to abc@test.com.")
+      htmlContent must include("From the Customs Declaration Service")
+    }
   }
 
   "Email notifications " should {
@@ -243,6 +256,10 @@ class CustomsFinancialsSpec extends TemplateComparisonSpec with CommonParamsForS
       compareContent("customs_financials_requested_cash_account_transactions", params)(
         customsFinancialsTemplate
       )
+    }
+
+    "have matching content in customs_financials_change_email" in {
+      compareContent("customs_financials_change_email", commonParameters)(customsFinancialsTemplate)
     }
   }
 

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/customsFinancials/CustomsFinancialsSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/customsFinancials/CustomsFinancialsSpec.scala
@@ -17,9 +17,6 @@
 package uk.gov.hmrc.hmrcemailrenderer.templates.customsFinancials
 
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import preview.TemplateParams
-import preview.TemplateParams2
-import uk.gov.hmrc.hmrcemailrenderer.templates.cf.ContactFormsTemplates.cf_enquiry_confirmation
 import uk.gov.hmrc.hmrcemailrenderer.templates.{ CommonParamsForSpec, TemplateComparisonSpec, customsfinancials }
 
 class CustomsFinancialsSpec extends TemplateComparisonSpec with CommonParamsForSpec with GuiceOneAppPerSuite {
@@ -257,9 +254,7 @@ class CustomsFinancialsSpec extends TemplateComparisonSpec with CommonParamsForS
     "have matching content in customs_financials_requested_cash_account_transactions" in {
       val params = commonParameters ++ Map("recipientName_FullName" -> "ABC ltd")
 
-      compareContent("customs_financials_requested_cash_account_transactions", params)(
-        customsFinancialsTemplate
-      )
+      compareContent("customs_financials_requested_cash_account_transactions", params)(customsFinancialsTemplate)
     }
 
     "have matching content in customs_financials_change_email_address" in {


### PR DESCRIPTION
Description - Add CDS Financials templates for primary email address change

New Template id named customs_financials_change_email_address has been added

JIRA Ticket - https://jira.tools.tax.service.gov.uk/browse/MMCA-5190

Below checklist has been followed

- Write the content for your email. One of your priorities should be to make sure that the email is not marked as spam by the user. See our [Content recommendations](https://github.com/hmrc/hmrc-email-renderer/blob/master/CONTRIBUTING.md#content-recommendations)

- Decide what is the most suitable priority for the template. See our [Volumes and priority recommendations](https://github.com/hmrc/hmrc-email-renderer/blob/master/CONTRIBUTING.md#volumes-and-priority-recommendations)

- Fork this repository and make the necessary code changes. See [How to add a template](https://github.com/hmrc/hmrc-email-renderer/blob/master/CONTRIBUTING.md#how-to-add-a-template)

- Verify that your template looks right when rendered - use the [preview mode](https://github.com/hmrc/hmrc-email-renderer/blob/master/README.md#preview-mode)

- Run the tests locally with sbt fmt clean test it:test