### PR TITLE
DC-7749  | removed redundant text from template.

### DIFF
--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcAgentFileUploadUnsuccessful.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcAgentFileUploadUnsuccessful.scala.html
@@ -28,8 +28,6 @@
 
 <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">For reference, the File ID (MessageRefId) is:<br>@{params("messageRefId")}</p>
 
-<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">You can check the errors in the CBC service and upload an updated XML file.</p>
-
 <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">For security reasons, we have not included a link to this service in this email.</p>
 
 <h2 style="margin: 60px 0 30px; font-size: 24px;">If you need help</h2>

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcAgentFileUploadUnsuccessful.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcAgentFileUploadUnsuccessful.scala.txt
@@ -16,8 +16,6 @@ You can check the errors in the country-by-country reporting service and upload 
 For reference, the File ID (MessageRefId) is:
 @{params("messageRefId")}
 
-You can check the errors in the CBC service and upload an updated XML file.
-
 For security reasons, we have not included a link to this service in this email.
 
 


### PR DESCRIPTION
Ticket: https://jira.tools.tax.service.gov.uk/browse/DC-7679
I noticed some text "You can check the errors in the CBC service and upload an updated XML file." that was redundant  in the **File failed checks for CBC - agent** template and I have removed it.
FYI: The links below show the new content of the emails.

[File failed checks for CBC - agent](https://docs.google.com/document/d/1oQA_bnork__DPySIZ67cONADVftqngTp3HzKXXWo5N0/edit?usp=sharing)

Screenshot:
<img width="1077" height="1200" alt="cbc_agent_file_upload_unsuccessful_html_updated" src="https://github.com/user-attachments/assets/b12e1d5d-7827-42ee-8188-20bbca43b704" />

Txt:
<img width="1161" height="684" alt="cbc_agent_file_upload_unsuccessful_txt_updated" src="https://github.com/user-attachments/assets/1888f34f-42de-4fa0-aff2-5cb39f4486f0" />


