### PR TITLE
DAC6-3869 | updated cbc org upload and agent upload successful template

### DIFF
--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -2331,15 +2331,18 @@ object TemplateParams2 {
     ),
     "cbc_file_upload_successful" -> Map(
       "contactName"   -> "Joe Bloggs",
+      "orgName"       -> "ABC Ltd",
       "dateSubmitted" -> "11:14am on 20 March 2023",
       "messageRefId"  -> "XACBC0000123778",
-      "reportType"    -> "The file contains corrections for an existing report."
+      "reportType"    -> "The file contains new information for the reporting period.",
+      "endPeriod"     -> "31 December 2023",
+      "startPeriod"   -> "1 January 2023"
     ),
     "cbc_file_upload_unsuccessful" -> Map(
-      "contactName"       -> "Joe Bloggs",
-      "clientTradingName" -> "ABC Ltd",
-      "dateSubmitted"     -> "11:14am on 20 March 2023",
-      "messageRefId"      -> "XACBC0000123778"
+      "contactName"   -> "Joe Bloggs",
+      "orgName"       -> "ABC Ltd",
+      "dateSubmitted" -> "11:14am on 20 March 2023",
+      "messageRefId"  -> "XACBC0000123778"
     ),
     "cbc_agent_file_upload_successful" -> Map(
       "contactName"       -> "Joe Bloggs",
@@ -2347,7 +2350,9 @@ object TemplateParams2 {
       "messageRefId"      -> "XACBC0000123778",
       "cbcId"             -> "XWCBC0000000058",
       "clientTradingName" -> "ABC Ltd",
-      "reportType"        -> "The file contains corrections for an existing report."
+      "reportType"        -> "The file contains new information for the reporting period.",
+      "endPeriod"         -> "31 December 2023",
+      "startPeriod"       -> "1 January 2023"
     ),
     "cbc_agent_file_upload_unsuccessful" -> Map(
       "contactName"       -> "Joe Bloggs",

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcAgentFileUploadSuccessful.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcAgentFileUploadSuccessful.scala.html
@@ -16,19 +16,19 @@
 
 @import uk.gov.hmrc.hmrcemailrenderer.templates.cbcrnew.html._
 @(params: Map[String, Any])
-@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "File successfully sent for the CBC reporting service") {
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "File successfully sent for CBC") {
 
-<p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 30px 0;">Dear @params("contactName")</p>
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Dear @params("contactName")</p>
 
-<p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 30px 0;">We have received the file for your client @params("clientTradingName") with the CBC ID @params("cbcId"). The file passed the country-by-country reporting checks at @params("dateSubmitted").</p>
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">We have received the file for your client @params("clientTradingName") with the CBC ID @params("cbcId"). The file passed the country-by-country reporting checks at @params("dateSubmitted"). This is for the reporting period @params("startPeriod") to @params("endPeriod").</p>
 
-<p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 30px 0;">Print or save a copy of this email for your records.</p>
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Print or save a copy of this email for your records.</p>
 
-<p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 30px 0;">For reference, the File ID (MessageRefId) is: @params("messageRefId")</p>
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">For reference, the File ID (MessageRefId) is: <br/>@params("messageRefId")</p>
 
-<p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 30px 0;">@params("reportType")</p>
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">@params("reportType")</p>
 
-<p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 30px 0;">For security reasons, we have not included a link to this service in this email.</p>
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">For security reasons, we have not included a link to this service in this email.</p>
 
 
 <h2 style="line-height: 1.315789474; font-size: 24px; margin: 60px 0 30px 0;">What happens next</h2>

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcAgentFileUploadSuccessful.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcAgentFileUploadSuccessful.scala.txt
@@ -1,15 +1,18 @@
 @import uk.gov.hmrc.hmrcemailrenderer.templates.cbcrnew.html._
 @(params: Map[String, Any])
 
-File successfully sent for the CBC reporting service
+File successfully sent for CBC
 
 Dear @{params("contactName")}
 
-We have received the file for your client @params("clientTradingName") with the CBC ID @{params("cbcId")}. The file passed the country-by-country reporting checks at @{params("dateSubmitted")}
+We have received the file for your client @params("clientTradingName") with the CBC ID @{params("cbcId")}.
+The file passed the country-by-country reporting checks at @{params("dateSubmitted")}
+This is for the reporting period @params("startPeriod") to @params("endPeriod").
 
 Print or save a copy of this email for your records.
 
-For reference, the File ID (MessageRefId) is: @{params("messageRefId")}
+For reference, the File ID (MessageRefId) is:
+@{params("messageRefId")}
 
 @params("reportType")
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcFileUploadSuccessful.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcFileUploadSuccessful.scala.html
@@ -15,24 +15,24 @@
  *@
 
 @(params: Map[String, Any])
-@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "File successfully sent for the CBC reporting service") {
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, "File successfully sent for CBC") {
 
-<p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 30px 0;">Dear @{params("contactName")}</p>
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Dear @{params("contactName")}</p>
 
-<p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 30px 0;">We have received your file, which passed the country-by-country reporting checks at @{params("dateSubmitted")}.</p>
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">We have received your file for @{params("orgName")}, which passed the country-by-country reporting checks at @{params("dateSubmitted")}. This is for the reporting period @{params("startPeriod")} to @{params("endPeriod")}.</p>
 
-<p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 30px 0;">Print or save a copy of this email for your records.</p>
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Print or save a copy of this email for your records.</p>
 
-<p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 30px 0;">For reference, the File ID (MessageRefId) is: @{params("messageRefId")}</p>
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">For reference, the File ID (MessageRefId) is: <br/>@{params("messageRefId")}</p>
 
-<p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 30px 0;">@params("reportType")</p>
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">@params("reportType")</p>
 
-<p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 30px 0;">For security reasons, we have not included a link to this service in this email.</p>
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">For security reasons, we have not included a link to this service in this email.</p>
 
 <h2 style="line-height: 1.315789474; font-size: 24px; margin: 60px 0 30px 0;">What happens next</h2>
 
-<p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 60px 0;">We will contact you if we have any questions about your report.</p>
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 60px 0;">We will contact you if we have any questions about your report.</p>
 
-<p style="font-size: 20px; line-height: 1.315789474; margin: 0 0 60px 0;">From the HMRC CBC service</p>
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 60px 0;">From the HMRC CBC service</p>
 
 }

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcFileUploadSuccessful.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcFileUploadSuccessful.scala.txt
@@ -1,14 +1,17 @@
 @(params: Map[String, Any])
 
-File successfully sent for the CBC reporting service
+File successfully sent for CBC
 
 Dear @{params("contactName")}
 
-We have received your file, which passed the country-by-country reporting checks at @{params("dateSubmitted")}
+We have received your file for @{params("orgName")}, which passed the
+country-by-country reporting checks at @{params("dateSubmitted")}.
+This is for the reporting period @{params("startPeriod")} to @{params("endPeriod")}.
 
 Print or save a copy of this email for your records.
 
-For reference, the File ID (MessageRefId) is: @{params("messageRefId")}
+For reference, the File ID (MessageRefId) is:
+@{params("messageRefId")}
 
 @params("reportType")
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcFileUploadUnsuccessful.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcFileUploadUnsuccessful.scala.html
@@ -22,7 +22,7 @@
 
 <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">Dear @{params("contactName")}</p>
 
-<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">There is a problem with the file you tried to send for @{params("clientTradingName")} at @{params("dateSubmitted")} for country-by-country reporting.</p>
+<p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">There is a problem with the file you tried to send for @{params("orgName")} at @{params("dateSubmitted")} for country-by-country reporting.</p>
 
 <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">You must send another version. Not sending another report on time may result in a penalty.</p>
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcFileUploadUnsuccessful.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcFileUploadUnsuccessful.scala.txt
@@ -6,7 +6,7 @@ There is a problem with your file for CBC
 Dear @{params("contactName")}
 
 
-There is a problem with the file you tried to send for @{params("clientTradingName")}  at at @{params("dateSubmitted")} for country-by-country reporting.
+There is a problem with the file you tried to send for @{params("orgName")}  at at @{params("dateSubmitted")} for country-by-country reporting.
 
 You must send another version. Not sending another report on time may result in a penalty.
 


### PR DESCRIPTION
Ticket: https://jira.tools.tax.service.gov.uk/browse/DC-7752
- Updated the cbc File Upload unsuccessful template to pull organisation name from orgName param.
- Updated the cbc org file Upload and Agent successful template to match the latest changes.

Here below are the latest screenshots:
**CBC Org Successful upload**
**Html**
<img width="1034" height="791" alt="cbc_org_upload_successful_html" src="https://github.com/user-attachments/assets/2d701e9a-4db6-4d31-96e2-9205b9ef6031" />
**Txt**
<img width="1141" height="579" alt="cbc_org_upload_successful_txt" src="https://github.com/user-attachments/assets/b2efa782-9337-437b-99f0-1c8d4c87d580" />

**CBC Agent Upload success**
Html
<img width="893" height="716" alt="cbc_agent_successful_html" src="https://github.com/user-attachments/assets/074543eb-3be7-4763-b070-f706485aa798" />
Txt
<img width="1058" height="689" alt="cbc_agent_successful_txt" src="https://github.com/user-attachments/assets/20714dc0-97b2-4553-b23f-cb7ef020f54b" />
