### PR TITLE
fixed some formatting issues

### DIFF
--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcAgentFileUploadSuccessful.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcAgentFileUploadSuccessful.scala.txt
@@ -6,7 +6,7 @@ File successfully sent for CBC
 Dear @{params("contactName")}
 
 We have received the file for your client @params("clientTradingName") with the CBC ID @{params("cbcId")}.
-The file passed the country-by-country reporting checks at @{params("dateSubmitted")}
+The file passed the country-by-country reporting checks at @{params("dateSubmitted")}.
 This is for the reporting period @params("startPeriod") to @params("endPeriod").
 
 Print or save a copy of this email for your records.

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcAgentFileUploadUnsuccessful.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcAgentFileUploadUnsuccessful.scala.txt
@@ -1,7 +1,7 @@
 @import uk.gov.hmrc.hmrcemailrenderer.templates.cbcrnew.html._
 @(params: Map[String, Any])
 
-File failed checks for the CBC reporting service
+There is a problem with your file for CBC
 
 
 Dear @{params("contactName")}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcFileUploadUnsuccessful.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcFileUploadUnsuccessful.scala.txt
@@ -6,7 +6,7 @@ There is a problem with your file for CBC
 Dear @{params("contactName")}
 
 
-There is a problem with the file you tried to send for @{params("orgName")}  at at @{params("dateSubmitted")} for country-by-country reporting.
+There is a problem with the file you tried to send for @{params("orgName")} at @{params("dateSubmitted")} for country-by-country reporting.
 
 You must send another version. Not sending another report on time may result in a penalty.
 

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcRegistrationSuccessfulOrganisation.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcRegistrationSuccessfulOrganisation.scala.html
@@ -31,7 +31,7 @@
 
 <ul style="list-style-type:disc">
  <li style="font-size: 19px;">search for ‘country-by-country reporting’ on GOV.UK</li>
- <li style="font-size: 19px;">sign into the service</li>
+ <li style="font-size: 19px;">sign in to the service</li>
 </ul>
 
 <p style="font-size: 19px; line-height: 1.315789474; margin: 0 0 30px 0;">You can email your HMRC Customer Compliance Manager or <br/> msb.countrybycountryreportingmailbox@@hmrc.gov.uk for help.</p>

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcRegistrationSuccessfulOrganisation.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/cbcrnew/cbcRegistrationSuccessfulOrganisation.scala.txt
@@ -15,7 +15,7 @@ How to make a report
 To make a report:
 
 search for ‘country-by-country reporting’ on GOV.UK
-sign into the service
+sign in to the service
 
 You can email your HMRC Customer Compliance Manager or
 msb.countrybycountryreportingmailbox@@hmrc.gov.uk for help.


### PR DESCRIPTION
I have updated the following templates:
1. CBC registration email - HTML : changed text from "into" to "in to".
2. CBC registration email - Text : changed text from "into" to "in to".
3. cbc_agent_file_upload_successful - Text: Added a full stop
4. cbc_agent_file_upload_unsuccessful - Text: Added the correct header text

Here are the template screenshots:
**cbc_agent_file_upload_successful-Text**
<img width="1011" height="1177" alt="3869-cbc_agent_file_upload_successful-Text-retest" src="https://github.com/user-attachments/assets/463e09fc-2b7b-4983-b4ab-14eab4df156c" />
**cbc_agent_file_upload_unsuccessful-Text**
<img width="1011" height="1175" alt="3869-cbc_agent_file_upload_unsuccessful-Text-retest" src="https://github.com/user-attachments/assets/87cc5dbe-af01-4977-b5f2-61215ac5360e" />
**cbc_file_upload_unsuccessful-Text**
<img width="1010" height="1175" alt="3869-cbc_file_upload_unsuccessful-Text-Retest" src="https://github.com/user-attachments/assets/09dfb6de-0592-44ea-8526-9d20a2aac04a" />
**cbc_registration_successful_organisation** 
<img width="1007" height="1175" alt="3869-cbc_registration_successful_organisation -text- retest" src="https://github.com/user-attachments/assets/9d9659a0-24fc-44b5-aefc-8fb03e02de6d" />
**CBC registration email**
<img width="1004" height="1176" alt="3869-cbc_registration_successful_organisation-HTML-retest" src="https://github.com/user-attachments/assets/c63fa26f-df79-4e72-b3ff-480badeea7cd" />
