### PR TITLE
DC-7670 hmrc-email-renderer- fix footer crown

### DIFF
--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/childcare/childcareMainTemplate.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/childcare/childcareMainTemplate.scala.html
@@ -65,16 +65,21 @@
                     <td style="font-family: Helvetica, Arial, sans-serif;">
                         <table width="100%" cellspacing="0" cellpadding="0">
                             <tr>
-                                <td colspan="75%" style="font-family: Helvetica, Arial, sans-serif; padding: 20px;">
+                                <td colspan="75%" style="color: #0b0c0c; font-size: 14px; font-family: Helvetica, Arial, sans-serif; padding: 20px;">
 
-                                    If you’re unsure an email is from HMRC:
+                                    If you're unsure an email is from HMRC:
+
                                     <ul style="margin: 5px 0 0; padding-left: 20px;">
-                                        <li style="margin-bottom: 5px;">Do not reply to it or click on any links</li>
-                                        <li style="margin-bottom: 5px;">Report the suspicious email to HMRC - to find out how, go to GOV.UK and search for 'Avoid and report internet scams and phishing'</li>
+                                        <li style="margin-bottom: 5px;">
+                                            Do not reply to it or click on any links
+                                        </li>
+                                        <li style="margin-bottom: 5px;">
+                                            Report the suspicious email to HMRC - to find out how, go to GOV.UK and search for 'Avoid and report internet scams and phishing'
+                                        </li>
                                     </ul>
                                 </td>
                                 <td colspan="25%" align="right" style="font-family: Helvetica, Arial, sans-serif; padding: 20px;">
-                                    <img src="@{params("staticAssetUrlPrefix")}@{params("staticHmrcFrontendVersion")}/govuk/images/govuk-crest-2x.png" width="150">
+                                    <img src="@{params("staticAssetUrlPrefix")}@{params("staticHmrcFrontendVersion")}/assets/images/govuk-crest-2x.png" width="150">
                                 </td>
                             </tr>
                         </table>

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/childcare/childcareMainTemplate.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/childcare/childcareMainTemplate.scala.html
@@ -79,7 +79,7 @@
                                     </ul>
                                 </td>
                                 <td colspan="25%" align="right" style="font-family: Helvetica, Arial, sans-serif; padding: 20px;">
-                                    <img src="@{params("staticAssetUrlPrefix")}@{params("staticHmrcFrontendVersion")}/assets/images/govuk-crest-2x.png" width="150">
+                                     @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.footer_image(params)
                                 </td>
                             </tr>
                         </table>

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/helpers/footer_image.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/helpers/footer_image.scala.html
@@ -1,0 +1,18 @@
+@*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(params: Map[String, Any])
+<img src="@{params("staticAssetUrlPrefix")}@{params("staticHmrcFrontendVersion")}/assets/images/govuk-crest-2x.png" alt="GOV.UK" width="150">

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/helpers/template_main.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/helpers/template_main.scala.html
@@ -144,11 +144,7 @@
               </ul>
           </td>
         <td colspan="25%" align="right" style="font-family: Helvetica, Arial, sans-serif; padding: 20px;">
-            <img
-                    src="https://www.tax.service.gov.uk/assets/hmrc-frontend/6.86.0/assets/images/govuk-crest-2x.png"
-                    alt="GOV.UK"
-                    width="150"
-            />
+            @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.footer_image(params)
         </td>
       </tr>
     </table>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -127,7 +127,7 @@ templates {
     config {
         staticAssetUrlPrefix = "https://www.tax.service.gov.uk" # "http://localhost:9032"
         staticAssetVersion = "/assets/2.230.0"
-        staticHmrcFrontendVersion = "/assets/hmrc-frontend/5.66.0"
+        staticHmrcFrontendVersion = "/assets/hmrc-frontend/6.86.0"
         borderColour = "005EA5"
     }
 }


### PR DESCRIPTION

http://localhost:8950/hmrc-email-renderer/test-only/preview/html/childcare_taxfree_devolved


## After - copied the styling from the other templates 
<img width="620" height="162" alt="image" src="https://github.com/user-attachments/assets/eac761f1-5dcb-484e-ae2f-527d347df64d" />


Example template using non custom footer from library
http://localhost:8950/hmrc-email-renderer/test-only/preview/html/tamc_confirmation_pta?full_name=Mr%20Joe%20Bloggs


## Before

<img width="892" height="161" alt="image" src="https://github.com/user-attachments/assets/4ebea321-fecf-4673-b0e5-f201b43b0a89" />


