### PR TITLE
DC-8953 Fix GIR email accounting period showing wrong year

### DIFF
--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/pillar2/Pillar2DateTimes.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/pillar2/Pillar2DateTimes.scala
@@ -27,7 +27,7 @@ object Pillar2DateTimes {
         raw,
         DateTimeFormatter.ofPattern("dd/MM/yyyy")
       )
-      .format(DateTimeFormatter.ofPattern("d MMMM YYYY"))
+      .format(DateTimeFormatter.ofPattern("d MMMM yyyy"))
 
   def toTwelveHourUserFacing(raw: String): String =
     LocalTime.parse(raw).format(DateTimeFormatter.ofPattern("h:mma"))

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/pillar2/Pillar2DateTimesSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/pillar2/Pillar2DateTimesSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcemailrenderer.templates.pillar2
+
+import org.scalatestplus.play.PlaySpec
+import uk.gov.hmrc.hmrcemailrenderer.templates.pillar2.Pillar2DateTimes.*
+
+class Pillar2DateTimesSpec extends PlaySpec {
+
+  "ukAllNumericDateToUserFacing" must {
+
+    "convert a numeric date to a user-facing date" in {
+      ukAllNumericDateToUserFacing("01/04/2023") mustBe "1 April 2023"
+    }
+
+    // Regression test for DC-7988 / PIL-2596. 31 December 2025 falls in an ISO week
+    // whose Thursday is in 2026, so the previous week-based-year pattern (YYYY) produced
+    // "31 December 2026". The calendar-year pattern (yyyy) must keep the correct year.
+    "use the calendar year for dates in an ISO week belonging to the next year" in {
+      ukAllNumericDateToUserFacing("31/12/2025") mustBe "31 December 2025"
+    }
+
+    "use the calendar year for dates in an ISO week belonging to the previous year" in {
+      ukAllNumericDateToUserFacing("01/01/2023") mustBe "1 January 2023"
+    }
+  }
+}

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/pillar2/Pillar2TemplatesSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/pillar2/Pillar2TemplatesSpec.scala
@@ -79,6 +79,25 @@ class Pillar2TemplatesSpec extends PlaySpec with CommonParamsForSpec {
       txtContent must include("HM Revenue and Customs")
       txtContent must include("Customer Compliance Group")
     }
+
+    // Regression test (DC-7988 / PIL-2596). An accounting period ending on a date that falls
+    // in an ISO week belonging to the following calendar year (e.g. 31/12/2025) was previously
+    // rendered with the wrong year ("31 December 2026") because the date formatter used the
+    // week-based-year symbol (YYYY) instead of the calendar-year symbol (yyyy).
+    "render a year-end accounting period with the correct calendar year" in {
+      val yearEndParams = params ++ Map(
+        "accountingPeriodStart" -> "01/01/2025",
+        "accountingPeriodEnd"   -> "31/12/2025"
+      )
+
+      val htmlContent = successTemplate.htmlTemplate(yearEndParams).toString
+      htmlContent must include("Accounting period: 1 January 2025 to 31 December 2025")
+      htmlContent must not include "31 December 2026"
+
+      val txtContent = successTemplate.plainTemplate(yearEndParams).toString
+      txtContent must include("Accounting period: 1 January 2025 to 31 December 2025")
+      txtContent must not include "31 December 2026"
+    }
   }
 
   "GIR Generic Errors Template" must {


### PR DESCRIPTION
## Problem

GIR submission emails were displaying the wrong **year** in the accounting period when the period boundary fell at year-end.

For a submission CADX sent with `accountingPeriodStart = 01/01/2025` and `accountingPeriodEnd = 31/12/2025`, the email rendered:

> Accounting period: 1 January 2025 to **31 December 2026**

This is affecting live submissions.

## Root cause

`Pillar2DateTimes.ukAllNumericDateToUserFacing` formatted the output with `"d MMMM YYYY"`. In `java.time.DateTimeFormatter` the uppercase `YYYY` is the **week-based year** (ISO-8601 week-numbering year), not the calendar year (`yyyy`).

`31 December 2025` is a Wednesday whose ISO week (29 Dec 2025 – 4 Jan 2026) has its Thursday on 1 January 2026, so the week-based year resolves to **2026**. The bug only surfaces for dates in the year-end ISO-week overlap, which is why existing tests (using an April–March period) did not catch it.

## Fix

Change the output pattern from `YYYY` to `yyyy` so the calendar year is always used. This single helper feeds the accounting period start/end and submission date across all GIR templates.

## Tests

- Added `Pillar2DateTimesSpec` unit tests for the helper, including the year-end ISO-week boundary (`31/12/2025` → `31 December 2025`).
- Added a regression test to `Pillar2TemplatesSpec` for the GIR success template asserting a `01/01/2025`–`31/12/2025` period renders `1 January 2025 to 31 December 2025` (and not `31 December 2026`).