### PR TITLE
[DC-9220] - P2-CY+1: Create email template for annual tax code notice in English

### DIFF
--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -809,7 +809,7 @@ object TemplateParams {
         "fullName" -> "Mr Joe Bloggs"
       ),
       "annual_tax_estimate_message_alert" -> Map(
-        "fullName" -> "Mr Joe Bloggs"
+        "fullName" -> "Leslie Carter"
       ),
       "fandf_ask_help_notification" -> Map(
         "helperLastName"  -> "Bloggs",

--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -808,6 +808,9 @@ object TemplateParams {
       "tax_estimate_message_alert_cy" -> Map(
         "fullName" -> "Mr Joe Bloggs"
       ),
+      "annual_tax_estimate_message_alert" -> Map(
+        "fullName" -> "Mr Joe Bloggs"
+      ),
       "fandf_ask_help_notification" -> Map(
         "helperLastName"  -> "Bloggs",
         "helperFirstName" -> "Joe",

--- a/app/preview/TemplateParams.scala
+++ b/app/preview/TemplateParams.scala
@@ -809,7 +809,8 @@ object TemplateParams {
         "fullName" -> "Mr Joe Bloggs"
       ),
       "annual_tax_estimate_message_alert" -> Map(
-        "fullName" -> "Leslie Carter"
+        "fullName" -> "Leslie Carter",
+        "taxYear"  -> "2027"
       ),
       "fandf_ask_help_notification" -> Map(
         "helperLastName"  -> "Bloggs",

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/paye/PayeTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/paye/PayeTemplates.scala
@@ -44,7 +44,7 @@ object PayeTemplates {
       templateId = "annual_tax_estimate_message_alert",
       fromAddress = defaultFromAddress,
       service = PayAsYouEarn,
-      subject = "Check your tax update online",
+      subject = "Check your PAYE code change online",
       plainTemplate = txt.annualTaxEstimateMessageAlert.f,
       htmlTemplate = html.annualTaxEstimateMessageAlert.f
     ),

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/paye/PayeTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/paye/PayeTemplates.scala
@@ -42,7 +42,7 @@ object PayeTemplates {
     ),
     MessageTemplate.create(
       templateId = "annual_tax_estimate_message_alert",
-      fromAddress = defaultFromAddress,
+      fromAddress = FromAddress.noReply("HMRC Check your Income Tax service"),
       service = PayAsYouEarn,
       subject = "Check your PAYE code change online",
       plainTemplate = txt.annualTaxEstimateMessageAlert.f,

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/paye/PayeTemplates.scala
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/paye/PayeTemplates.scala
@@ -41,6 +41,14 @@ object PayeTemplates {
       htmlTemplate = html.taxEstimateMessageAlert_cy.f
     ),
     MessageTemplate.create(
+      templateId = "annual_tax_estimate_message_alert",
+      fromAddress = defaultFromAddress,
+      service = PayAsYouEarn,
+      subject = "Check your tax update online",
+      plainTemplate = txt.annualTaxEstimateMessageAlert.f,
+      htmlTemplate = html.annualTaxEstimateMessageAlert.f
+    ),
+    MessageTemplate.create(
       templateId = "newMessageAlert_P800",
       fromAddress = defaultFromAddress,
       service = PayAsYouEarn,

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/paye/annualTaxEstimateMessageAlert.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/paye/annualTaxEstimateMessageAlert.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/paye/annualTaxEstimateMessageAlert.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/paye/annualTaxEstimateMessageAlert.scala.html
@@ -21,14 +21,14 @@
 @uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, s"Your tax code will change from 6 April $currentYear") {
 <p style="margin: 0 0 30px; font-size: 19px;">Dear @{params("fullName")}</p>
 <p style="margin: 0 0 30px; font-size: 19px;">We've calculated your Income Tax for the next tax year (6 April @currentYear to 5 April @{currentYear+1}). The amount of tax you pay may change.</p>
-<p style="margin: 0 0 0px; font-size: 19px;">For security reasons, we do not give full details here.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">For security reasons, we do not give full details here.</p>
 
-<h2 id="how-to-check-new-tax-details" style="margin: 40px 0 30px; font-size: 24px;">How to check your new tax details</h2>
+<h2 id="how-to-check-new-tax-details" style="margin: 0 0 30px; font-size: 24px;">How to check your new tax details</h2>
 
 <p style="margin: 0 0 30px; font-size: 19px;">Sign in to your HMRC online account on GOV.UK or use the HMRC app. Go to the ‘Pay As You Earn (PAYE)’ section.</p>
-<p style="margin: 0 0 30px; font-size: 19px;">If you sign in using a business tax account, you may be able to use it to access your personal tax account.</p>
+<p style="margin: 30px 0 30px; font-size: 19px;">If you sign in using a business tax account, you may be able to use it to access your personal tax account.</p>
 
-<h2 id="why-you-got-this-email" style="margin: 40px 0 30px; font-size: 24px;">Why you’re receiving this email</h2>
+<h2 id="why-you-got-this-email" style="margin: 0 0 30px; font-size: 24px;">Why you’re receiving this email</h2>
 
 <p style="margin: 0 0 30px; font-size: 19px;">You’re receiving this email because you chose to receive email updates instead of letters by post.</p>
 <p style="margin: 0 0 30px; font-size: 19px;">For security reasons we have not included any links in this email.</p>

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/paye/annualTaxEstimateMessageAlert.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/paye/annualTaxEstimateMessageAlert.scala.html
@@ -14,13 +14,14 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.hmrcemailrenderer.templates.TemplateUtils.currentYear
-
 @(params: Map[String, Any])
 
-@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, s"Your tax code will change from 6 April $currentYear") {
+@currentTaxYear = {@params("taxYear")}
+@nextTaxYear = {@(currentTaxYear.toString.toInt+1)}
+
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, s"Your tax code will change from 6 April ${currentTaxYear}") {
 <p style="margin: 0 0 30px; font-size: 19px;">Dear @{params("fullName")}</p>
-<p style="margin: 0 0 30px; font-size: 19px;">We've calculated your Income Tax for the next tax year (6 April @currentYear to 5 April @{currentYear+1}). The amount of tax you pay may change.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">We've calculated your Income Tax for the next tax year (6 April @currentTaxYear to 5 April @nextTaxYear). The amount of tax you pay may change.</p>
 <p style="margin: 0 0 30px; font-size: 19px;">For security reasons, we do not give full details here.</p>
 
 <h2 id="how-to-check-new-tax-details" style="margin: 0 0 30px; font-size: 24px;">How to check your new tax details</h2>

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/paye/annualTaxEstimateMessageAlert.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/paye/annualTaxEstimateMessageAlert.scala.html
@@ -1,0 +1,36 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.hmrcemailrenderer.templates.TemplateUtils.currentYear
+
+@(params: Map[String, Any])
+
+@uk.gov.hmrc.hmrcemailrenderer.templates.helpers.html.template_main(params, s"Your tax code will change from 6 April $currentYear") {
+<p style="margin: 0 0 30px; font-size: 19px;">Dear @{params("fullName")}</p>
+<p style="margin: 0 0 30px; font-size: 19px;">We've calculated your Income Tax for the next tax year (6 April @currentYear to 5 April @{currentYear+1}). The amount of tax you pay may change.</p>
+<p style="margin: 0 0 0px; font-size: 19px;">For security reasons, we do not give full details here.</p>
+
+<h2 id="how-to-check-new-tax-details" style="margin: 30px 0 30px; font-size: 24px;">How to check your new tax details</h2>
+
+<p>Sign in to your HMRC online account on GOV.UK or use the HMRC app. Go to the ‘Pay As You Earn (PAYE)’ section.</p>
+<p>If you sign in using a business tax account, you may be able to use it to access your personal tax account.</p>
+
+<h2 id="why-you-got-this-email" style="margin: 30px 0 30px; font-size: 24px;">Why you’re receiving this email</h2>
+
+<p style="margin: 0 0 30px; font-size: 19px;">You’re receiving this email because you chose to receive email updates instead of letters by post.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">For security reasons we have not included any links in this email.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">From HMRC Check your Income Tax</p>
+}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/paye/annualTaxEstimateMessageAlert.scala.html
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/paye/annualTaxEstimateMessageAlert.scala.html
@@ -23,12 +23,12 @@
 <p style="margin: 0 0 30px; font-size: 19px;">We've calculated your Income Tax for the next tax year (6 April @currentYear to 5 April @{currentYear+1}). The amount of tax you pay may change.</p>
 <p style="margin: 0 0 0px; font-size: 19px;">For security reasons, we do not give full details here.</p>
 
-<h2 id="how-to-check-new-tax-details" style="margin: 30px 0 30px; font-size: 24px;">How to check your new tax details</h2>
+<h2 id="how-to-check-new-tax-details" style="margin: 40px 0 30px; font-size: 24px;">How to check your new tax details</h2>
 
-<p>Sign in to your HMRC online account on GOV.UK or use the HMRC app. Go to the ‘Pay As You Earn (PAYE)’ section.</p>
-<p>If you sign in using a business tax account, you may be able to use it to access your personal tax account.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">Sign in to your HMRC online account on GOV.UK or use the HMRC app. Go to the ‘Pay As You Earn (PAYE)’ section.</p>
+<p style="margin: 0 0 30px; font-size: 19px;">If you sign in using a business tax account, you may be able to use it to access your personal tax account.</p>
 
-<h2 id="why-you-got-this-email" style="margin: 30px 0 30px; font-size: 24px;">Why you’re receiving this email</h2>
+<h2 id="why-you-got-this-email" style="margin: 40px 0 30px; font-size: 24px;">Why you’re receiving this email</h2>
 
 <p style="margin: 0 0 30px; font-size: 19px;">You’re receiving this email because you chose to receive email updates instead of letters by post.</p>
 <p style="margin: 0 0 30px; font-size: 19px;">For security reasons we have not included any links in this email.</p>

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/paye/annualTaxEstimateMessageAlert.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/paye/annualTaxEstimateMessageAlert.scala.txt
@@ -1,0 +1,29 @@
+@import uk.gov.hmrc.hmrcemailrenderer.templates.TemplateUtils
+@import uk.gov.hmrc.hmrcemailrenderer.templates.TemplateUtils.currentYear
+
+@(params: Map[String, Any])Your tax code will change from 6 April @currentYear
+
+
+Dear @{params("fullName")}
+
+We've calculated your Income Tax for the next tax year (6 April @currentYear to 5 April @{currentYear+1}). The amount of tax you pay may change.
+
+For security reasons, we do not give full details here.
+
+
+How to check your new tax details
+
+Sign in to your HMRC online account on GOV.UK or use the HMRC app. Go to the ‘Pay As You Earn (PAYE)’ section.
+
+If you sign in using a business tax account, you may be able to use it to access your personal tax account.
+
+
+Why you’re receiving this email
+
+You’re receiving this email because you chose to receive email updates instead of letters by post.
+
+For security reasons we have not included any links in this email.
+
+From HMRC Check your Income Tax
+
+@{uk.gov.hmrc.hmrcemailrenderer.templates.helpers.txt.template_footer()}

--- a/app/uk/gov/hmrc/hmrcemailrenderer/templates/paye/annualTaxEstimateMessageAlert.scala.txt
+++ b/app/uk/gov/hmrc/hmrcemailrenderer/templates/paye/annualTaxEstimateMessageAlert.scala.txt
@@ -1,12 +1,11 @@
-@import uk.gov.hmrc.hmrcemailrenderer.templates.TemplateUtils
-@import uk.gov.hmrc.hmrcemailrenderer.templates.TemplateUtils.currentYear
-
-@(params: Map[String, Any])Your tax code will change from 6 April @currentYear
+@(params: Map[String, Any])Your tax code will change from 6 April @{params("taxYear")}
 
 
 Dear @{params("fullName")}
 
-We've calculated your Income Tax for the next tax year (6 April @currentYear to 5 April @{currentYear+1}). The amount of tax you pay may change.
+@defining(params("taxYear").toString.toInt + 1) { nextTaxYear =>
+We've calculated your Income Tax for the next tax year (6 April @{params("taxYear")} to 5 April @nextTaxYear). The amount of tax you pay may change.
+}
 
 For security reasons, we do not give full details here.
 

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/TemplateLocatorSpec.scala
@@ -928,6 +928,7 @@ class TemplateLocatorSpec extends AnyWordSpecLike with should.Matchers with Opti
         "tamc_update_reject_cy",
         "tax_estimate_message_alert",
         "tax_estimate_message_alert_cy",
+        "annual_tax_estimate_message_alert",
         "tcs_renewal_confirmation",
         "tctr_connection_removed",
         "tctr_connection_removed_cy",

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/paye/AnnualTaxEstimateMessageAlertSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/paye/AnnualTaxEstimateMessageAlertSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/paye/AnnualTaxEstimateMessageAlertSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/paye/AnnualTaxEstimateMessageAlertSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.hmrcemailrenderer.templates.paye
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.{ EitherValues, OptionValues }
-import uk.gov.hmrc.hmrcemailrenderer.templates.{ CommonParamsForSpec, TemplateLoader, TemplateLocator, TemplateUtils }
+import uk.gov.hmrc.hmrcemailrenderer.templates.{ CommonParamsForSpec, TemplateLoader, TemplateLocator }
 
 import java.time.LocalDate
 

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/paye/AnnualTaxEstimateMessageAlertSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/paye/AnnualTaxEstimateMessageAlertSpec.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.hmrcemailrenderer.templates.paye
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.{ EitherValues, OptionValues }
+import uk.gov.hmrc.hmrcemailrenderer.templates.{ CommonParamsForSpec, TemplateLoader, TemplateLocator, TemplateUtils }
+
+import java.time.LocalDate
+
+class AnnualTaxEstimateMessageAlertSpec
+    extends AnyWordSpecLike with Matchers with OptionValues with EitherValues with TemplateLoader
+    with CommonParamsForSpec {
+
+  "annual_tax_estimate_message_alert" should {
+    val currentYear = LocalDate.now().getYear
+    val templateLocator = new TemplateLocator {}
+    val params = commonParameters ++ Map("fullName" -> "Leslie Carter")
+    val template = templateLocator.templateGroups("PAYE").find(_.templateId == "annual_tax_estimate_message_alert").get
+
+    "render correct subject" in {
+      template.subject(Map.empty) shouldBe "Check your tax update online"
+      template.fromAddress(Map.empty) shouldBe "HMRC digital <noreply@tax.service.gov.uk>"
+    }
+
+    "render correct html content" in {
+      val htmlContent = template.htmlTemplate(params).toString
+
+      htmlContent should include(s"Your tax code will change from 6 April $currentYear")
+      htmlContent should include("Dear Leslie Carter")
+      htmlContent should include(
+        s"We've calculated your Income Tax for the next tax year (" +
+          s"6 April $currentYear to 5 April ${currentYear + 1}). The amount of tax you pay may change."
+      )
+      htmlContent should include("For security reasons, we do not give full details here.")
+      htmlContent should include("How to check your new tax details")
+
+      htmlContent should include(
+        "Sign in to your HMRC online account on GOV.UK or use the HMRC app. Go to the ‘Pay As You Earn (PAYE)’ section."
+      )
+
+      htmlContent should include(
+        "If you sign in using a business tax account, you may be able to use it to access your personal tax account."
+      )
+
+      htmlContent should include("Why you’re receiving this email")
+      htmlContent should include(
+        "You’re receiving this email because you chose to receive email updates instead of letters by post."
+      )
+
+      htmlContent should include("For security reasons we have not included any links in this email.")
+      htmlContent should include("From HMRC Check your Income Tax")
+    }
+
+    "render correct text content" in {
+      val txtContent = template.plainTemplate(params).toString
+
+      txtContent should include(s"Your tax code will change from 6 April $currentYear")
+      txtContent should include("Dear Leslie Carter")
+      txtContent should include(
+        s"We've calculated your Income Tax for the next tax year (" +
+          s"6 April $currentYear to 5 April ${currentYear + 1}). The amount of tax you pay may change."
+      )
+      txtContent should include("For security reasons, we do not give full details here.")
+      txtContent should include("How to check your new tax details")
+
+      txtContent should include(
+        "Sign in to your HMRC online account on GOV.UK or use the HMRC app. Go to the ‘Pay As You Earn (PAYE)’ section."
+      )
+
+      txtContent should include(
+        "If you sign in using a business tax account, you may be able to use it to access your personal tax account."
+      )
+
+      txtContent should include("Why you’re receiving this email")
+      txtContent should include(
+        "You’re receiving this email because you chose to receive email updates instead of letters by post."
+      )
+
+      txtContent should include("For security reasons we have not included any links in this email.")
+      txtContent should include("From HMRC Check your Income Tax")
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/paye/AnnualTaxEstimateMessageAlertSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/paye/AnnualTaxEstimateMessageAlertSpec.scala
@@ -34,7 +34,7 @@ class AnnualTaxEstimateMessageAlertSpec
     val template = templateLocator.templateGroups("PAYE").find(_.templateId == "annual_tax_estimate_message_alert").get
 
     "render correct subject" in {
-      template.subject(Map.empty) shouldBe "Check your tax update online"
+      template.subject(Map.empty) shouldBe "Check your PAYE code change online"
       template.fromAddress(Map.empty) shouldBe "HMRC digital <noreply@tax.service.gov.uk>"
     }
 

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/paye/AnnualTaxEstimateMessageAlertSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/paye/AnnualTaxEstimateMessageAlertSpec.scala
@@ -28,9 +28,8 @@ class AnnualTaxEstimateMessageAlertSpec
     with CommonParamsForSpec {
 
   "annual_tax_estimate_message_alert" should {
-    val currentYear = LocalDate.now().getYear
     val templateLocator = new TemplateLocator {}
-    val params = commonParameters ++ Map("fullName" -> "Leslie Carter")
+    val params = commonParameters ++ Map("fullName" -> "Leslie Carter", "taxYear" -> "2027")
     val template = templateLocator.templateGroups("PAYE").find(_.templateId == "annual_tax_estimate_message_alert").get
 
     "render correct subject" in {
@@ -41,11 +40,11 @@ class AnnualTaxEstimateMessageAlertSpec
     "render correct html content" in {
       val htmlContent = template.htmlTemplate(params).toString
 
-      htmlContent should include(s"Your tax code will change from 6 April $currentYear")
+      htmlContent should include(s"Your tax code will change from 6 April 2027")
       htmlContent should include("Dear Leslie Carter")
       htmlContent should include(
         s"We've calculated your Income Tax for the next tax year (" +
-          s"6 April $currentYear to 5 April ${currentYear + 1}). The amount of tax you pay may change."
+          "6 April 2027 to 5 April 2028). The amount of tax you pay may change."
       )
       htmlContent should include("For security reasons, we do not give full details here.")
       htmlContent should include("How to check your new tax details")
@@ -70,11 +69,11 @@ class AnnualTaxEstimateMessageAlertSpec
     "render correct text content" in {
       val txtContent = template.plainTemplate(params).toString
 
-      txtContent should include(s"Your tax code will change from 6 April $currentYear")
+      txtContent should include(s"Your tax code will change from 6 April 2027")
       txtContent should include("Dear Leslie Carter")
       txtContent should include(
         s"We've calculated your Income Tax for the next tax year (" +
-          s"6 April $currentYear to 5 April ${currentYear + 1}). The amount of tax you pay may change."
+          "6 April 2027 to 5 April 2028). The amount of tax you pay may change."
       )
       txtContent should include("For security reasons, we do not give full details here.")
       txtContent should include("How to check your new tax details")

--- a/test/uk/gov/hmrc/hmrcemailrenderer/templates/paye/AnnualTaxEstimateMessageAlertSpec.scala
+++ b/test/uk/gov/hmrc/hmrcemailrenderer/templates/paye/AnnualTaxEstimateMessageAlertSpec.scala
@@ -35,7 +35,7 @@ class AnnualTaxEstimateMessageAlertSpec
 
     "render correct subject" in {
       template.subject(Map.empty) shouldBe "Check your PAYE code change online"
-      template.fromAddress(Map.empty) shouldBe "HMRC digital <noreply@tax.service.gov.uk>"
+      template.fromAddress(Map.empty) shouldBe "HMRC Check your Income Tax service <noreply@tax.service.gov.uk>"
     }
 
     "render correct html content" in {


### PR DESCRIPTION
Description - English template for annual tax notice

below has been as part of this PR

- add test class named AnnualTaxEstimateMessageAlertSpec
- add relevant code with template id annual_tax_estimate_message_alert
- minor refactoring

Note - The year range that would be displayed would be 2026 and 2027 as it is dynamic and will be generated according to the current year. Next year (when these templates would be deployed), it would be 2027-2028.